### PR TITLE
add trace command and backup capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 The `vt` binary encapsulates several utility tools for Vitess, providing a comprehensive suite for testing, summarizing, and query analysis.
 
 ## Tools Included
-- **`vt tester`**: A testing utility using the same test files as the [MySQL Test Framework](https://github.com/mysql/mysql-server/tree/8.0/mysql-test). It compares the results of identical queries executed on both MySQL and Vitess (vtgate), helping to ensure compatibility.
+- **`vt test`**: A testing utility using the same test files as the [MySQL Test Framework](https://github.com/mysql/mysql-server/tree/8.0/mysql-test). It compares the results of identical queries executed on both MySQL and Vitess (vtgate), helping to ensure compatibility.
 - **`vt benchstat`**: A tool used to summarize or compare trace logs or key logs for deeper analysis.
 - **`vt keys`**: A utility that analyzes query logs and provides information about queries, tables, and column usage. It integrates with `vt benchstat` for summarizing and comparing query logs.
+- **`vt trace`**: A tool that generates a trace of the query execution plan using the `vexplain trace` tool for detailed analysis. 
 
 ## Installation
 You can install `vt` using the following command:
@@ -100,6 +101,16 @@ The generated trace logs can be summarized or compared using `vt benchstat`:
    ```
 
    This summary shows the columns of the `customer` table, along with their usage percentages in filters, groupings, and joins across the queries in the log.
+
+## Using `--backup-path` Flag
+
+The `--backup-path` flag allows `tester` and `trace` to initialize tests from a database backup rather than an empty database.
+This is particularly helpful when verifying compatibility during version upgrades or testing stateful operations.
+
+Example:
+```bash
+vt test --backup-path /path/to/backup -vschema t/vschema.json t/basic.test
+```
 
 ## Contributing
 

--- a/go/cmd/benchstat.go
+++ b/go/cmd/benchstat.go
@@ -28,7 +28,7 @@ func benchstat() *cobra.Command {
 		Short:   "Compares and analyses a trace output",
 		Example: "vt benchstat old.json new.json",
 		Args:    cobra.RangeArgs(1, 2),
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			vtbenchstat.Run(args)
 		},
 	}

--- a/go/cmd/root.go
+++ b/go/cmd/root.go
@@ -35,6 +35,7 @@ func Execute() {
 
 	root.AddCommand(benchstat())
 	root.AddCommand(testerCmd())
+	root.AddCommand(tracerCmd())
 	root.AddCommand(keysCmd())
 
 	err := root.Execute()

--- a/go/cmd/tester.go
+++ b/go/cmd/tester.go
@@ -48,5 +48,7 @@ func testerCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&cfg.Sharded, "sharded", false, "Run all tests on a sharded keyspace and using auto-vschema. This cannot be used with either -vschema or -vtexplain-vschema.")
 	cmd.Flags().IntVar(&cfg.NumberOfShards, "number-of-shards", 0, "Number of shards to use for the sharded keyspace.")
 
+	cmd.Flags().StringVar(&cfg.BackupDir, "backup-path", "", "Restore from backup before running the tester")
+
 	return cmd
 }

--- a/go/cmd/tester.go
+++ b/go/cmd/tester.go
@@ -26,13 +26,14 @@ func testerCmd() *cobra.Command {
 	var cfg vttester.Config
 
 	cmd := &cobra.Command{
+		Aliases: []string{"test"},
 		Use:     "tester ",
 		Short:   "Test the given workload against both Vitess and MySQL.",
 		Example: "vt tester ",
 		Args:    cobra.MinimumNArgs(1),
-		Run: func(_ *cobra.Command, args []string) {
+		RunE: func(_ *cobra.Command, args []string) error {
 			cfg.Tests = args
-			vttester.Run(cfg)
+			return vttester.Run(cfg)
 		},
 	}
 

--- a/go/cmd/tester.go
+++ b/go/cmd/tester.go
@@ -33,6 +33,7 @@ func testerCmd() *cobra.Command {
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			cfg.Tests = args
+			cfg.Compare = true
 			return vttester.Run(cfg)
 		},
 	}

--- a/go/keys/keys.go
+++ b/go/keys/keys.go
@@ -25,6 +25,7 @@ import (
 	"slices"
 	"sort"
 
+	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
@@ -32,8 +33,6 @@ import (
 
 	"github.com/vitessio/vt/go/data"
 	"github.com/vitessio/vt/go/typ"
-
-	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
 func Run(fileName string) error {
@@ -57,7 +56,7 @@ func run(out io.Writer, fileName string) error {
 		switch query.Type {
 		case typ.Skip, typ.Error, typ.VExplain:
 			skip = true
-		case typ.RemoveFile, typ.Unknown:
+		case typ.Unknown:
 			return fmt.Errorf("unknown command type: %s", query.Type)
 		case typ.Comment, typ.CommentWithCommand, typ.EmptyLine, typ.WaitForAuthoritative, typ.SkipIfBelowVersion:
 			// no-op for keys

--- a/go/tester/empty_query_runner.go
+++ b/go/tester/empty_query_runner.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tester
+
+import (
+	"github.com/vitessio/vt/go/data"
+	"github.com/vitessio/vt/go/tester/state"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/utils"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+)
+
+type Empty struct{}
+
+func (e *Empty) NewQueryRunner(Reporter, CreateTableHandler, utils.MySQLCompare, *cluster.LocalProcessCluster, *vindexes.VSchema) QueryRunner {
+	return e
+}
+
+func (e *Empty) Close() {}
+
+func (e *Empty) runQuery(data.Query, sqlparser.Statement, *state.State) error { return nil }

--- a/go/tester/execute.go
+++ b/go/tester/execute.go
@@ -94,6 +94,12 @@ func SetupCluster(cfg Config) (_ ClusterInfo, err error) {
 		return ClusterInfo{}, err
 	}
 
+	if cfg.BackupDir != "" {
+		clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs,
+			"--backup_storage_implementation", "file",
+			"--file_backup_storage_root", cfg.BackupDir)
+	}
+
 	var ksNames []string
 	keyspaces, vschema := getKeyspaces(cfg.VschemaFile, cfg.VtExplainVschemaFile, defaultKeyspaceName, cfg.Sharded)
 	for _, keyspace := range keyspaces {

--- a/go/tester/run.go
+++ b/go/tester/run.go
@@ -82,7 +82,11 @@ func Run(cfg Config) error {
 
 	log.Infof("running tests: %v", cfg.Tests)
 
-	clusterInfo := SetupCluster(cfg)
+	clusterInfo, err := SetupCluster(cfg)
+	if err != nil {
+		return err
+	}
+
 	defer clusterInfo.closer()
 
 	// remove errors folder if exists

--- a/go/tester/run.go
+++ b/go/tester/run.go
@@ -40,6 +40,8 @@ type Config struct {
 	Tests                []string
 	NumberOfShards       int
 	Compare              bool
+
+	BackupDir string
 }
 
 func (cfg Config) GetNumberOfShards() int {

--- a/go/tester/tester.go
+++ b/go/tester/tester.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
@@ -46,7 +45,7 @@ type (
 
 		olap        bool
 		ksNames     []string
-		vschema     vindexes.VSchema
+		vschema     *vindexes.VSchema
 		vschemaFile string
 		vexplain    string
 
@@ -62,29 +61,19 @@ type (
 	}
 
 	QueryRunnerFactory interface {
-		NewQueryRunner(reporter Reporter, handleCreateTable CreateTableHandler, comparer utils.MySQLCompare, cluster *cluster.LocalProcessCluster) QueryRunner
+		NewQueryRunner(reporter Reporter, handleCreateTable CreateTableHandler, comparer utils.MySQLCompare, cluster *cluster.LocalProcessCluster, vschema *vindexes.VSchema) QueryRunner
 		Close()
 	}
 )
 
-func NewTester(
-	name string,
-	reporter Reporter,
-	clusterInstance *cluster.LocalProcessCluster,
-	vtParams, mysqlParams mysql.ConnParams,
-	olap bool,
-	ksNames []string,
-	vschema vindexes.VSchema,
-	vschemaFile string,
-	factory QueryRunnerFactory,
-) *Tester {
+func NewTester(name string, reporter Reporter, info ClusterInfo, olap bool, vschema *vindexes.VSchema, vschemaFile string, factory QueryRunnerFactory) *Tester {
 	t := &Tester{
 		name:            name,
 		reporter:        reporter,
-		vtParams:        vtParams,
-		mysqlParams:     mysqlParams,
-		clusterInstance: clusterInstance,
-		ksNames:         ksNames,
+		vtParams:        info.vtParams,
+		mysqlParams:     info.mysqlParams,
+		clusterInstance: info.clusterInstance,
+		ksNames:         info.ksNames,
 		vschema:         vschema,
 		vschemaFile:     vschemaFile,
 		olap:            olap,
@@ -98,7 +87,7 @@ func NewTester(
 	if !t.autoVSchema() {
 		createTableHandler = func(*sqlparser.CreateTable) func() { return func() {} }
 	}
-	t.qr = factory.NewQueryRunner(reporter, createTableHandler, mcmp, clusterInstance)
+	t.qr = factory.NewQueryRunner(reporter, createTableHandler, mcmp, info.clusterInstance, vschema)
 
 	return t
 }
@@ -121,6 +110,76 @@ func (t *Tester) postProcess() {
 
 const PERM os.FileMode = 0o755
 
+func (t *Tester) runVexplain(q string) {
+	result, err := t.curr.VtConn.ExecuteFetch(fmt.Sprintf("vexplain %s %s", t.vexplain, q), -1, false)
+	t.vexplain = ""
+	if err != nil {
+		t.reporter.AddFailure(err)
+	}
+
+	t.reporter.AddInfo(fmt.Sprintf("VExplain Output:\n %s\n", result.Rows[0][0].ToString()))
+}
+
+func (t *Tester) skipIfBelow(q string) {
+	strs := strings.Split(q, " ")
+	if len(strs) != 3 {
+		t.reporter.AddFailure(fmt.Errorf("incorrect syntax for typ.Q_SKIP_IF_BELOW_VERSION in: %v", q))
+		return
+	}
+	v, err := strconv.Atoi(strs[2])
+	if err != nil {
+		t.reporter.AddFailure(err)
+		return
+	}
+	err = t.state.SetSkipBelowVersion(strs[1], v)
+	if err != nil {
+		t.reporter.AddFailure(err)
+	}
+}
+
+func (t *Tester) prepareVExplain(q string) {
+	strs := strings.Split(q, " ")
+	if len(strs) != 2 {
+		t.reporter.AddFailure(fmt.Errorf("incorrect syntax for typ.VExplain in: %v", q))
+		return
+	}
+
+	t.vexplain = strs[1]
+}
+
+func (t *Tester) handleQuery(q data.Query) {
+	var err error
+	switch q.Type {
+	case typ.Skip:
+		err = t.state.SetSkipNext()
+	case typ.SkipIfBelowVersion:
+		t.skipIfBelow(q.Query)
+	case typ.Error:
+		err = t.state.SetErrorExpected()
+	case typ.VExplain:
+		t.prepareVExplain(q.Query)
+	case typ.WaitForAuthoritative:
+		t.waitAuthoritative(q.Query)
+	case typ.Query:
+		if t.vexplain == "" {
+			t.runQuery(q)
+			return
+		}
+		t.runVexplain(q.Query)
+	case typ.VitessOnly:
+		err = vitessOrMySQLOnly(q.Query, t.state.BeginVitessOnly, t.state.EndVitessOnly)
+	case typ.MysqlOnly:
+		err = vitessOrMySQLOnly(q.Query, t.state.BeginMySQLOnly, t.state.EndMySQLOnly)
+	case typ.Reference:
+		err = t.state.SetReference()
+	default:
+		t.reporter.AddFailure(fmt.Errorf("%s not supported", q.Type.String()))
+	}
+	if err != nil {
+		t.reporter.AddFailure(err)
+	}
+}
+
 func (t *Tester) Run() error {
 	t.preProcess()
 	if t.autoVSchema() {
@@ -133,77 +192,7 @@ func (t *Tester) Run() error {
 	}
 
 	for _, q := range queries {
-		switch q.Type {
-		case typ.Skip:
-			err := t.state.SetSkipNext()
-			if err != nil {
-				t.reporter.AddFailure(err)
-			}
-		case typ.SkipIfBelowVersion:
-			strs := strings.Split(q.Query, " ")
-			if len(strs) != 3 {
-				t.reporter.AddFailure(fmt.Errorf("incorrect syntax for typ.Q_SKIP_IF_BELOW_VERSION in: %v", q.Query))
-				continue
-			}
-			v, err := strconv.Atoi(strs[2])
-			if err != nil {
-				t.reporter.AddFailure(err)
-				continue
-			}
-			err = t.state.SetSkipBelowVersion(strs[1], v)
-			if err != nil {
-				t.reporter.AddFailure(err)
-			}
-		case typ.Error:
-			err = t.state.SetErrorExpected()
-			if err != nil {
-				t.reporter.AddFailure(err)
-			}
-		case typ.VExplain:
-			strs := strings.Split(q.Query, " ")
-			if len(strs) != 2 {
-				t.reporter.AddFailure(fmt.Errorf("incorrect syntax for typ.VExplain in: %v", q.Query))
-				continue
-			}
-
-			t.vexplain = strs[1]
-		case typ.WaitForAuthoritative:
-			t.waitAuthoritative(q.Query)
-		case typ.Query:
-			if t.vexplain != "" {
-				result, err := t.curr.VtConn.ExecuteFetch(fmt.Sprintf("vexplain %s %s", t.vexplain, q.Query), -1, false)
-				t.vexplain = ""
-				if err != nil {
-					t.reporter.AddFailure(err)
-				}
-
-				t.reporter.AddInfo(fmt.Sprintf("VExplain Output:\n %s\n", result.Rows[0][0].ToString()))
-			}
-
-			t.runQuery(q)
-		case typ.RemoveFile:
-			err = os.Remove(strings.TrimSpace(q.Query))
-			if err != nil {
-				return fmt.Errorf("failed to remove file: %w", err)
-			}
-		case typ.VitessOnly:
-			err := vitessOrMySQLOnly(q.Query, t.state.BeginVitessOnly, t.state.EndVitessOnly)
-			if err != nil {
-				t.reporter.AddFailure(err)
-			}
-		case typ.MysqlOnly:
-			err := vitessOrMySQLOnly(q.Query, t.state.BeginMySQLOnly, t.state.EndMySQLOnly)
-			if err != nil {
-				t.reporter.AddFailure(err)
-			}
-		case typ.Reference:
-			err := t.state.SetReference()
-			if err != nil {
-				t.reporter.AddFailure(err)
-			}
-		default:
-			t.reporter.AddFailure(fmt.Errorf("%s not supported", q.Type.String()))
-		}
+		t.handleQuery(q)
 	}
 	fmt.Printf("%s\n", t.reporter.Report())
 

--- a/go/tester/tester.go
+++ b/go/tester/tester.go
@@ -19,6 +19,7 @@ package tester
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -43,7 +44,10 @@ type (
 		clusterInstance *cluster.LocalProcessCluster
 		vtParams        mysql.ConnParams
 		mysqlParams     *mysql.ConnParams
-		curr            utils.MySQLCompare
+
+		// connections
+
+		MySQLConn, VtConn *mysql.Conn
 
 		olap        bool
 		ksNames     []string
@@ -87,7 +91,6 @@ func NewTester(name string, reporter Reporter, info ClusterInfo, olap bool, vsch
 	if t.mysqlParams != nil {
 		mcmp, err = utils.NewMySQLCompare(t.reporter, t.vtParams, *t.mysqlParams)
 		exitIf(err, "creating MySQLCompare")
-		t.curr = mcmp
 	} else {
 		vtConn, err := mysql.Connect(context.Background(), &t.vtParams)
 		exitIf(err, "connecting to MySQL")
@@ -104,24 +107,39 @@ func NewTester(name string, reporter Reporter, info ClusterInfo, olap bool, vsch
 
 func (t *Tester) preProcess() {
 	if t.olap {
-		_, err := t.curr.VtConn.ExecuteFetch("set workload = 'olap'", 0, false)
+		_, err := t.VtConn.ExecuteFetch("set workload = 'olap'", 0, false)
 		exitIf(err, "setting workload to olap by executing query")
 	}
 }
 
-func (t *Tester) postProcess() {
-	r, err := t.curr.MySQLConn.ExecuteFetch("show tables", 1000, true)
-	exitIf(err, "running show tables")
-	for _, row := range r.Rows {
-		t.curr.Exec(fmt.Sprintf("drop table %s", row[0].ToString()))
+func (t *Tester) postProcess() error {
+	r, err := t.MySQLConn.ExecuteFetch("show tables", 1000, true)
+	if err != nil {
+		return fmt.Errorf("running show tables: %w", err)
 	}
-	t.curr.Close()
+	for _, row := range r.Rows {
+		_, err := t.VtConn.ExecuteFetch(fmt.Sprintf("drop table %s", row[0].ToString()), 100, false)
+		if err != nil {
+			return fmt.Errorf("dropping table %s: %w", row[0].ToString(), err)
+		}
+		if t.MySQLConn != nil {
+			_, err := t.MySQLConn.ExecuteFetch(fmt.Sprintf("drop table %s", row[0].ToString()), 100, false)
+			if err != nil {
+				return fmt.Errorf("dropping table %s: %w", row[0].ToString(), err)
+			}
+		}
+	}
+	t.VtConn.Close()
+	if t.MySQLConn != nil {
+		t.MySQLConn.Close()
+	}
+	return nil
 }
 
 const PERM os.FileMode = 0o755
 
 func (t *Tester) runVexplain(q string) {
-	result, err := t.curr.VtConn.ExecuteFetch(fmt.Sprintf("vexplain %s %s", t.vexplain, q), -1, false)
+	result, err := t.VtConn.ExecuteFetch(fmt.Sprintf("vexplain %s %s", t.vexplain, q), -1, false)
 	t.vexplain = ""
 	if err != nil {
 		t.reporter.AddFailure(err)
@@ -190,10 +208,19 @@ func (t *Tester) handleQuery(q data.Query) {
 	}
 }
 
-func (t *Tester) Run() error {
+func (t *Tester) Run() (err error) {
 	t.preProcess()
 	if t.autoVSchema() {
-		defer t.postProcess()
+		defer func() {
+			postErr := t.postProcess()
+			if postErr == nil {
+				return
+			}
+			if err == nil {
+				err = postErr
+			}
+			err = errors.Join(err, postErr)
+		}()
 	}
 	queries, err := data.LoadQueries(t.name)
 	if err != nil {

--- a/go/tester/tracer.go
+++ b/go/tester/tracer.go
@@ -86,7 +86,7 @@ func (t *Tracer) runQuery(q data.Query, ast sqlparser.Statement, state *state.St
 			errs = append(errs, err)
 		}
 
-		if state.RunOnMySQL() {
+		if t.MySQLConn != nil && state.RunOnMySQL() {
 			// we need to run the DMLs on mysql as well
 			_, err = t.MySQLConn.ExecuteFetch(q.Query, 10000, false)
 			if err != nil {

--- a/go/tester/tracer.go
+++ b/go/tester/tracer.go
@@ -27,6 +27,7 @@ import (
 	"vitess.io/vitess/go/test/endtoend/utils"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
 
 	"github.com/vitessio/vt/go/data"
 	"github.com/vitessio/vt/go/tester/state"
@@ -58,14 +59,15 @@ func NewTracerFactory(traceFile *os.File, inner QueryRunnerFactory) *TracerFacto
 	}
 }
 
-func (t *TracerFactory) NewQueryRunner(
-	reporter Reporter,
-	handleCreateTable CreateTableHandler,
-	comparer utils.MySQLCompare,
-	cluster *cluster.LocalProcessCluster,
-) QueryRunner {
-	inner := t.inner.NewQueryRunner(reporter, handleCreateTable, comparer, cluster)
-	return newTracer(t.traceFile, comparer.MySQLConn, comparer.VtConn, reporter, inner)
+func (t *TracerFactory) NewQueryRunner(reporter Reporter, handleCreateTable CreateTableHandler, comparer utils.MySQLCompare, cluster *cluster.LocalProcessCluster, vschema *vindexes.VSchema) QueryRunner {
+	inner := t.inner.NewQueryRunner(reporter, handleCreateTable, comparer, cluster, vschema)
+	return &Tracer{
+		traceFile: t.traceFile,
+		MySQLConn: comparer.MySQLConn,
+		VtConn:    comparer.VtConn,
+		reporter:  reporter,
+		inner:     inner,
+	}
 }
 
 func (t *TracerFactory) Close() {
@@ -73,20 +75,6 @@ func (t *TracerFactory) Close() {
 	exitIf(err, "failed to write closing bracket")
 	err = t.traceFile.Close()
 	exitIf(err, "failed to close trace file")
-}
-
-func newTracer(traceFile *os.File,
-	mySQLConn, vtConn *mysql.Conn,
-	reporter Reporter,
-	inner QueryRunner,
-) QueryRunner {
-	return &Tracer{
-		traceFile: traceFile,
-		MySQLConn: mySQLConn,
-		VtConn:    vtConn,
-		reporter:  reporter,
-		inner:     inner,
-	}
 }
 
 func (t *Tracer) runQuery(q data.Query, ast sqlparser.Statement, state *state.State) error {

--- a/go/typ/typ.go
+++ b/go/typ/typ.go
@@ -23,7 +23,6 @@ type CmdType int
 const (
 	Query CmdType = iota
 	Error
-	RemoveFile
 	Skip
 	Unknown
 	Comment
@@ -37,10 +36,9 @@ const (
 	Reference
 )
 
-var commandMap = map[string]CmdType{
+var commandMap = map[string]CmdType{ //nolint:gochecknoglobals // this is instead of a const
 	"query":                 Query,
 	"error":                 Error,
-	"remove_file":           RemoveFile,
 	"skip":                  Skip,
 	"skip_if_below_version": SkipIfBelowVersion,
 	"vexplain":              VExplain,


### PR DESCRIPTION
# Description

This PR introduces two key features:

1. **`trace` command:**  
   The `trace` command accepts a query log and runs `vexplain trace` on all queries without comparing the results against vanilla MySQL. This simplifies query tracing directly within Vitess workflows.
   
2. **`--backup-path` flag for `tester` and `trace`:**  
   A new `--backup-path` flag has been added to both the `tester` and `trace` commands. This allows tests to run from a database backup rather than an empty database. It's particularly useful when testing upgrades to newer Vitess versions by starting from a pre-existing state.
