### PR TITLE
Group same failed queries together in keys's output

### DIFF
--- a/go/keys/keys_test.go
+++ b/go/keys/keys_test.go
@@ -50,6 +50,7 @@ func TestKeysNonAuthoritativeTable(t *testing.T) {
 	si := &schemaInfo{}
 	ql := &queryList{
 		queries: make(map[string]*QueryAnalysisResult),
+		failed:  make(map[string]*QueryFailedResult),
 	}
 	process(q, si, ql)
 

--- a/go/keys/keys_test.go
+++ b/go/keys/keys_test.go
@@ -21,10 +21,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/vitessio/vt/go/data"
 	"github.com/vitessio/vt/go/typ"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestKeys(t *testing.T) {

--- a/go/summarize/summarize-keys.go
+++ b/go/summarize/summarize-keys.go
@@ -58,6 +58,7 @@ type (
 	FailuresSummary struct {
 		Query string
 		Error string
+		Count int
 	}
 
 	graphKey struct {
@@ -296,10 +297,10 @@ func renderFailures(md *markdown.MarkDown, failures []FailuresSummary) {
 	}
 	md.PrintHeader("Failures", 2)
 
-	headers := []string{"Query", "Error"}
+	headers := []string{"Query", "Error", "Count"}
 	var rows [][]string
 	for _, failure := range failures {
-		rows = append(rows, []string{failure.Query, failure.Error})
+		rows = append(rows, []string{failure.Query, failure.Error, strconv.Itoa(failure.Count)})
 	}
 	md.PrintTable(headers, rows)
 }
@@ -368,6 +369,7 @@ func summarizeKeysQueries(queries *keys.Output) ([]TableSummary, []FailuresSumma
 		failures = append(failures, FailuresSummary{
 			Query: query.Query,
 			Error: query.Error,
+			Count: len(query.LineNumbers),
 		})
 	}
 

--- a/go/summarize/testdata/keys-log.json
+++ b/go/summarize/testdata/keys-log.json
@@ -525,12 +525,10 @@
     "failed": [
       {
         "query": "I am a failing query;",
-        "lineNumber": 463,
-        "error": "syntax error at position 2 near 'I'"
-      },
-      {
-        "query": "I am a failing query;",
-        "lineNumber": 781,
+        "lineNumbers": [
+          463,
+          781
+        ],
         "error": "syntax error at position 2 near 'I'"
       }
     ]

--- a/go/summarize/testdata/keys-summary.md
+++ b/go/summarize/testdata/keys-summary.md
@@ -148,8 +148,7 @@ partsupp ↔ supplier (Occurrences: 1)
 
 ```
 ## Failures
-|Query|Error|
-|---|---|
-|I am a failing query;|syntax error at position 2 near 'I'|
-|I am a failing query;|syntax error at position 2 near 'I'|
+|Query|Error|Count|
+|---|---|---|
+|I am a failing query;|syntax error at position 2 near 'I'|2|
 


### PR DESCRIPTION
This PR groups query that failed multiple times into a single JSON element instead of repeating the same query/failure.

```json
"failed": [
      {
        "query": "I am a failing query;",
        "lineNumbers": [
          463,
          781
        ],
        "error": "syntax error at position 2 near 'I'"
      }
    ]
```

```
## Failures
|Query|Error|Count|
|---|---|---|
|I am a failing query;|syntax error at position 2 near 'I'|2|
```