### PR TITLE
Improve keys report by sorting joins by occurences

### DIFF
--- a/go/summarize/summarize-keys.go
+++ b/go/summarize/summarize-keys.go
@@ -242,13 +242,13 @@ func renderTablesJoined(md *markdown.MarkDown, summary *keys.Output) {
 		md.PrintHeader("Tables Joined", 2)
 	}
 
-	type foo struct {
+	type joinDetails struct {
 		Tbl1, Tbl2  string
 		Occurrences int
 		predicates  []operators.JoinPredicate
 	}
 
-	var joins []foo
+	var joins []joinDetails
 	for tables, predicates := range g {
 		occurrences := 0
 		for _, count := range predicates {
@@ -258,7 +258,7 @@ func renderTablesJoined(md *markdown.MarkDown, summary *keys.Output) {
 		sort.Slice(joinPredicates, func(i, j int) bool {
 			return joinPredicates[i].String() < joinPredicates[j].String()
 		})
-		joins = append(joins, foo{
+		joins = append(joins, joinDetails{
 			Tbl1:        tables.Tbl1,
 			Tbl2:        tables.Tbl2,
 			Occurrences: occurrences,

--- a/go/summarize/summarize-keys.go
+++ b/go/summarize/summarize-keys.go
@@ -24,7 +24,6 @@ import (
 	"slices"
 	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	"vitess.io/vitess/go/slice"
@@ -238,53 +237,50 @@ func renderTablesJoined(md *markdown.MarkDown, summary *keys.Output) {
 			g.AddJoinPredicate(key, pred)
 		}
 	}
-	ks := slices.Collect(maps.Keys(g))
-	slices.SortFunc(ks, func(a, b graphKey) int {
-		if a.Tbl1 == b.Tbl1 {
-			return strings.Compare(a.Tbl2, b.Tbl2)
-		}
-		return strings.Compare(a.Tbl1, b.Tbl1)
-	})
 
 	if len(g) > 0 {
 		md.PrintHeader("Tables Joined", 2)
 	}
 
-	// we really want the output to be deterministic
-	tables := slices.Collect(maps.Keys(g))
-	sort.Slice(tables, func(i, j int) bool {
-		if tables[i].Tbl1 == tables[j].Tbl1 {
-			return tables[i].Tbl2 < tables[j].Tbl2
+	type foo struct {
+		Tbl1, Tbl2  string
+		Occurrences int
+		predicates  []operators.JoinPredicate
+	}
+
+	var joins []foo
+	for tables, predicates := range g {
+		occurrences := 0
+		for _, count := range predicates {
+			occurrences += count
 		}
-		return tables[i].Tbl1 < tables[j].Tbl1
+		joinPredicates := slices.Collect(maps.Keys(predicates))
+		sort.Slice(joinPredicates, func(i, j int) bool {
+			return joinPredicates[i].String() < joinPredicates[j].String()
+		})
+		joins = append(joins, foo{
+			Tbl1:        tables.Tbl1,
+			Tbl2:        tables.Tbl2,
+			Occurrences: occurrences,
+			predicates:  joinPredicates,
+		})
+	}
+
+	sort.Slice(joins, func(i, j int) bool {
+		return joins[i].Occurrences > joins[j].Occurrences
 	})
 
 	md.Println("```")
-	for _, table := range tables {
-		predicates := g[table]
-		numberOfPreds := len(predicates)
-		totalt := 0
-		for _, count := range predicates {
-			totalt += count
-		}
-		md.Printf("%s ↔ %s (Occurrences: %d)\n", table.Tbl1, table.Tbl2, totalt)
-
-		// we want the output to be deterministic
-		preds := slices.Collect(maps.Keys(predicates))
-		sort.Slice(preds, func(i, j int) bool {
-			return preds[i].String() < preds[j].String()
-		})
-
-		for _, predicate := range preds {
-			count := predicates[predicate]
-			numberOfPreds--
+	for _, join := range joins {
+		md.Printf("%s ↔ %s (Occurrences: %d)\n", join.Tbl1, join.Tbl2, join.Occurrences)
+		for i, pred := range join.predicates {
 			var s string
-			if numberOfPreds == 0 {
+			if i == len(join.predicates)-1 {
 				s = "└─"
 			} else {
 				s = "├─"
 			}
-			md.Printf("%s %s %d%%\n", s, predicate.String(), (count*100)/totalt)
+			md.Printf("%s %s\n", s, pred.String())
 		}
 		md.NewLine()
 	}

--- a/go/summarize/testdata/keys-summary.md
+++ b/go/summarize/testdata/keys-summary.md
@@ -1,7 +1,7 @@
 # Query Analysis Report
 
-**Date of Analysis**: 2024-11-09 10:28:32  
-**Analyzed File**: `go/summarize/testdata/keys-log.json`
+**Date of Analysis**: 2024-01-01 01:02:03  
+**Analyzed File**: `testdata/keys-log.json`
 
 ## Tables
 |Table Name|Reads|Writes|

--- a/go/summarize/testdata/keys-summary.md
+++ b/go/summarize/testdata/keys-summary.md
@@ -1,7 +1,7 @@
 # Query Analysis Report
 
-**Date of Analysis**: 2024-01-01 01:02:03  
-**Analyzed File**: `testdata/keys-log.json`
+**Date of Analysis**: 2024-11-09 10:28:32  
+**Analyzed File**: `go/summarize/testdata/keys-log.json`
 
 ## Tables
 |Table Name|Reads|Writes|
@@ -108,43 +108,43 @@
 
 ## Tables Joined
 ```
-customer ↔ nation (Occurrences: 3)
-└─ customer.c_nationkey = nation.n_nationkey 100%
+lineitem ↔ orders (Occurrences: 10)
+└─ lineitem.l_orderkey = orders.o_orderkey
 
 customer ↔ orders (Occurrences: 7)
-└─ customer.c_custkey = orders.o_custkey 100%
-
-customer ↔ supplier (Occurrences: 1)
-└─ customer.c_nationkey = supplier.s_nationkey 100%
-
-lineitem ↔ lineitem (Occurrences: 2)
-├─ lineitem.l_orderkey = lineitem.l_orderkey 50%
-└─ lineitem.l_suppkey != lineitem.l_suppkey 50%
-
-lineitem ↔ orders (Occurrences: 10)
-└─ lineitem.l_orderkey = orders.o_orderkey 100%
-
-lineitem ↔ part (Occurrences: 3)
-└─ lineitem.l_partkey = part.p_partkey 100%
-
-lineitem ↔ partsupp (Occurrences: 2)
-├─ lineitem.l_partkey = partsupp.ps_partkey 50%
-└─ lineitem.l_suppkey = partsupp.ps_suppkey 50%
-
-lineitem ↔ supplier (Occurrences: 5)
-└─ lineitem.l_suppkey = supplier.s_suppkey 100%
-
-nation ↔ region (Occurrences: 2)
-└─ nation.n_regionkey = region.r_regionkey 100%
+└─ customer.c_custkey = orders.o_custkey
 
 nation ↔ supplier (Occurrences: 6)
-└─ nation.n_nationkey = supplier.s_nationkey 100%
+└─ nation.n_nationkey = supplier.s_nationkey
 
-part ↔ partsupp (Occurrences: 1)
-└─ part.p_partkey = partsupp.ps_partkey 100%
+lineitem ↔ supplier (Occurrences: 5)
+└─ lineitem.l_suppkey = supplier.s_suppkey
+
+lineitem ↔ part (Occurrences: 3)
+└─ lineitem.l_partkey = part.p_partkey
+
+customer ↔ nation (Occurrences: 3)
+└─ customer.c_nationkey = nation.n_nationkey
+
+lineitem ↔ lineitem (Occurrences: 2)
+├─ lineitem.l_orderkey = lineitem.l_orderkey
+└─ lineitem.l_suppkey != lineitem.l_suppkey
+
+lineitem ↔ partsupp (Occurrences: 2)
+├─ lineitem.l_partkey = partsupp.ps_partkey
+└─ lineitem.l_suppkey = partsupp.ps_suppkey
+
+nation ↔ region (Occurrences: 2)
+└─ nation.n_regionkey = region.r_regionkey
 
 partsupp ↔ supplier (Occurrences: 1)
-└─ partsupp.ps_suppkey = supplier.s_suppkey 100%
+└─ partsupp.ps_suppkey = supplier.s_suppkey
+
+part ↔ partsupp (Occurrences: 1)
+└─ part.p_partkey = partsupp.ps_partkey
+
+customer ↔ supplier (Occurrences: 1)
+└─ customer.c_nationkey = supplier.s_nationkey
 
 ```
 ## Failures


### PR DESCRIPTION
The list of joins is easier to get an overview over when the joins are sorted by how common they are.