### PR TITLE
Add table row count to summary output

### DIFF
--- a/go/cmd/keys.go
+++ b/go/cmd/keys.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -70,6 +69,6 @@ func configureLoader(inputType string, needsBindVars bool) (data.Loader, error) 
 	case "vtgate-log":
 		return data.VtGateLogLoader{NeedsBindVars: needsBindVars}, nil
 	default:
-		return nil, errors.New(fmt.Sprintf("invalid input type: must be %s", allowedInputTypes))
+		return nil, fmt.Errorf("invalid input type: must be %s", allowedInputTypes)
 	}
 }

--- a/go/cmd/keys.go
+++ b/go/cmd/keys.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -53,9 +54,11 @@ func keysCmd() *cobra.Command {
 	return cmd
 }
 
+const allowedInputTypes = "'sql', 'mysql-log' or 'vtgate-log'"
+
 func addInputTypeFlag(cmd *cobra.Command, s *string) {
 	*s = "sql"
-	cmd.Flags().StringVar(s, "input-type", "sql", "Specifies the type of input file: 'sql' or 'mysql-log'")
+	cmd.Flags().StringVar(s, "input-type", "sql", fmt.Sprintf("Specifies the type of input file: %s", allowedInputTypes))
 }
 
 func configureLoader(inputType string, needsBindVars bool) (data.Loader, error) {
@@ -67,6 +70,6 @@ func configureLoader(inputType string, needsBindVars bool) (data.Loader, error) 
 	case "vtgate-log":
 		return data.VtGateLogLoader{NeedsBindVars: needsBindVars}, nil
 	default:
-		return nil, errors.New("invalid input type: must be 'sql' or 'mysql-log'")
+		return nil, errors.New(fmt.Sprintf("invalid input type: must be %s", allowedInputTypes))
 	}
 }

--- a/go/cmd/root.go
+++ b/go/cmd/root.go
@@ -37,6 +37,7 @@ func Execute() {
 	root.AddCommand(testerCmd())
 	root.AddCommand(tracerCmd())
 	root.AddCommand(keysCmd())
+	root.AddCommand(schemaCmd())
 
 	err := root.Execute()
 	if err != nil {

--- a/go/cmd/schema.go
+++ b/go/cmd/schema.go
@@ -18,19 +18,20 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/vitessio/vt/go/schema"
 	"vitess.io/vitess/go/mysql"
+
+	"github.com/vitessio/vt/go/schema"
 )
 
-var vtParams mysql.ConnParams
-
 func schemaCmd() *cobra.Command {
+	var vtParams mysql.ConnParams
+
 	cmd := &cobra.Command{
 		Use:     "schema ",
 		Short:   "Loads info from the database including row counts",
 		Example: "vt schema",
 		Args:    cobra.ExactArgs(0),
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			cfg := schema.Config{
 				VTParams: vtParams,
 			}
@@ -38,14 +39,12 @@ func schemaCmd() *cobra.Command {
 			return schema.Run(cfg)
 		},
 	}
-	registerFlags(cmd)
-	return cmd
-}
 
-func registerFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&vtParams.Host, "host", "", "127.0.0.1", "Database host")
 	cmd.Flags().IntVarP(&vtParams.Port, "port", "", 3306, "Database port")
 	cmd.Flags().StringVarP(&vtParams.Uname, "user", "", "root", "Database user")
 	cmd.Flags().StringVarP(&vtParams.Pass, "password", "", "", "Database password")
 	cmd.Flags().StringVarP(&vtParams.DbName, "database", "", "", "Database name")
+
+	return cmd
 }

--- a/go/cmd/schema.go
+++ b/go/cmd/schema.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/vitessio/vt/go/schema"
+	"vitess.io/vitess/go/mysql"
+)
+
+var vtParams mysql.ConnParams
+
+func schemaCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "schema ",
+		Short:   "Loads info from the database including row counts",
+		Example: "vt schema",
+		Args:    cobra.ExactArgs(0),
+		RunE: func(_ *cobra.Command, args []string) error {
+			cfg := schema.Config{
+				VTParams: vtParams,
+			}
+
+			return schema.Run(cfg)
+		},
+	}
+	registerFlags(cmd)
+	return cmd
+}
+
+func registerFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&vtParams.Host, "host", "", "127.0.0.1", "Database host")
+	cmd.Flags().IntVarP(&vtParams.Port, "port", "", 3306, "Database port")
+	cmd.Flags().StringVarP(&vtParams.Uname, "user", "", "root", "Database user")
+	cmd.Flags().StringVarP(&vtParams.Pass, "password", "", "", "Database password")
+	cmd.Flags().StringVarP(&vtParams.DbName, "database", "", "", "Database name")
+}

--- a/go/cmd/summarize.go
+++ b/go/cmd/summarize.go
@@ -24,7 +24,6 @@ import (
 
 func summarizeCmd() *cobra.Command {
 	var hotMetric string
-	var schemaInfoPath string
 
 	cmd := &cobra.Command{
 		Use:     "summarize old_file.json [new_file.json]",
@@ -33,12 +32,11 @@ func summarizeCmd() *cobra.Command {
 		Example: "vt summarize old.json new.json",
 		Args:    cobra.RangeArgs(1, 2),
 		Run: func(_ *cobra.Command, args []string) {
-			summarize.Run(args, hotMetric, schemaInfoPath)
+			summarize.Run(args, hotMetric)
 		},
 	}
 
 	cmd.Flags().StringVar(&hotMetric, "hot-metric", "total-time", "Metric to determine hot queries (options: usage-count, total-rows-examined, avg-rows-examined, avg-time, total-time)")
-	cmd.Flags().StringVar(&schemaInfoPath, "schema-info-path", "", "Path to output of 'vt schema' command (optional)")
 
 	return cmd
 }

--- a/go/cmd/summarize.go
+++ b/go/cmd/summarize.go
@@ -24,6 +24,7 @@ import (
 
 func summarizeCmd() *cobra.Command {
 	var hotMetric string
+	var schemaInfoPath string
 
 	cmd := &cobra.Command{
 		Use:     "summarize old_file.json [new_file.json]",
@@ -32,11 +33,12 @@ func summarizeCmd() *cobra.Command {
 		Example: "vt summarize old.json new.json",
 		Args:    cobra.RangeArgs(1, 2),
 		Run: func(_ *cobra.Command, args []string) {
-			summarize.Run(args, hotMetric)
+			summarize.Run(args, hotMetric, schemaInfoPath)
 		},
 	}
 
 	cmd.Flags().StringVar(&hotMetric, "hot-metric", "total-time", "Metric to determine hot queries (options: usage-count, total-rows-examined, avg-rows-examined, avg-time, total-time)")
+	cmd.Flags().StringVar(&schemaInfoPath, "schema-info-path", "", "Path to output of 'vt schema' command (optional)")
 
 	return cmd
 }

--- a/go/data/query.go
+++ b/go/data/query.go
@@ -45,6 +45,7 @@ type (
 		QueryTime, LockTime    float64
 		RowsSent, RowsExamined int
 		Timestamp              int64
+		UsageCount             int
 	}
 
 	errLoader struct {

--- a/go/data/typ.go
+++ b/go/data/typ.go
@@ -34,6 +34,7 @@ const (
 	VitessOnly
 	MysqlOnly
 	Reference
+	UsageCount
 )
 
 var commandMap = map[string]CmdType{ //nolint:gochecknoglobals // this is instead of a const
@@ -46,6 +47,7 @@ var commandMap = map[string]CmdType{ //nolint:gochecknoglobals // this is instea
 	"vitess_only":           VitessOnly,
 	"mysql_only":            MysqlOnly,
 	"reference":             Reference,
+	"usage_count":           UsageCount,
 }
 
 func (cmd CmdType) String() string {

--- a/go/keys/keys.go
+++ b/go/keys/keys.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"sort"
+
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators"

--- a/go/schema/schema.go
+++ b/go/schema/schema.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schema
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"vitess.io/vitess/go/mysql"
+)
+
+type Config struct {
+	VTParams mysql.ConnParams
+}
+
+func Run(cfg Config) error {
+	return run(os.Stdout, cfg)
+}
+
+func run(out io.Writer, cfg Config) error {
+	si, err := Get(cfg)
+	if err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(si, "", "  ")
+	if err != nil {
+		return err
+	}
+	out.Write(b)
+	return nil
+}
+
+type TableInfo struct {
+	Name string
+	Rows int
+}
+
+type SchemaInfo struct {
+	Tables []TableInfo
+}
+
+func Get(cfg Config) (*SchemaInfo, error) {
+	vtParams := &mysql.ConnParams{
+		Host:   cfg.VTParams.Host,
+		Port:   cfg.VTParams.Port,
+		Uname:  cfg.VTParams.Uname,
+		Pass:   cfg.VTParams.Pass,
+		DbName: cfg.VTParams.DbName,
+	}
+
+	vtConn, err := mysql.Connect(context.Background(), vtParams)
+	if err != nil {
+		return nil, err
+	}
+	defer vtConn.Close()
+	queryTableSizes := "SELECT table_name, table_rows FROM information_schema.tables WHERE table_schema = '%s' and table_type = 'BASE TABLE'"
+	qr, err := vtConn.ExecuteFetch(fmt.Sprintf(queryTableSizes, cfg.VTParams.DbName), -1, false)
+	if err != nil {
+		return nil, err
+	}
+	var tables []TableInfo
+	for _, row := range qr.Rows {
+		tableName := row[0].ToString()
+		tableRows, _ := row[1].ToInt64()
+		tables = append(tables, TableInfo{
+			Name: tableName,
+			Rows: int(tableRows),
+		})
+	}
+	schemaInfo := &SchemaInfo{
+		Tables: tables,
+	}
+	return schemaInfo, nil
+}
+
+func Load(fileName string) (*SchemaInfo, error) {
+	b, err := os.ReadFile(fileName)
+	if err != nil {
+		return nil, err
+	}
+	var si SchemaInfo
+	err = json.Unmarshal(b, &si)
+	if err != nil {
+		return nil, err
+	}
+	return &si, nil
+}

--- a/go/schema/schema.go
+++ b/go/schema/schema.go
@@ -48,12 +48,13 @@ func run(out io.Writer, cfg Config) error {
 }
 
 type TableInfo struct {
-	Name string
-	Rows int
+	Name string `json:"name"`
+	Rows int    `json:"rows"`
 }
 
 type Info struct {
-	Tables []TableInfo
+	FileType string      `json:"fileType"`
+	Tables   []TableInfo `json:"tables"`
 }
 
 func Get(cfg Config) (*Info, error) {

--- a/go/schema/schema.go
+++ b/go/schema/schema.go
@@ -43,8 +43,8 @@ func run(out io.Writer, cfg Config) error {
 	if err != nil {
 		return err
 	}
-	out.Write(b)
-	return nil
+	_, err = out.Write(b)
+	return err
 }
 
 type TableInfo struct {
@@ -52,11 +52,11 @@ type TableInfo struct {
 	Rows int
 }
 
-type SchemaInfo struct {
+type Info struct {
 	Tables []TableInfo
 }
 
-func Get(cfg Config) (*SchemaInfo, error) {
+func Get(cfg Config) (*Info, error) {
 	vtParams := &mysql.ConnParams{
 		Host:   cfg.VTParams.Host,
 		Port:   cfg.VTParams.Port,
@@ -84,18 +84,18 @@ func Get(cfg Config) (*SchemaInfo, error) {
 			Rows: int(tableRows),
 		})
 	}
-	schemaInfo := &SchemaInfo{
+	schemaInfo := &Info{
 		Tables: tables,
 	}
 	return schemaInfo, nil
 }
 
-func Load(fileName string) (*SchemaInfo, error) {
+func Load(fileName string) (*Info, error) {
 	b, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, err
 	}
-	var si SchemaInfo
+	var si Info
 	err = json.Unmarshal(b, &si)
 	if err != nil {
 		return nil, err

--- a/go/schema/schema_test.go
+++ b/go/schema/schema_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package schema
 
 import (
@@ -11,7 +27,7 @@ func TestSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, si)
 	require.NotEmpty(t, si.Tables)
-	require.Equal(t, 16, len(si.Tables))
+	require.Len(t, si.Tables, 16)
 	var tables []string
 	for _, table := range si.Tables {
 		tables = append(tables, table.Name)
@@ -26,7 +42,7 @@ func TestSchema(t *testing.T) {
 		case "film":
 			require.Equal(t, 1000, table.Rows)
 		default:
-			require.Greater(t, table.Rows, 0, "table %s has no rows", table.Name)
+			require.Positive(t, table.Rows, "table %s has no rows", table.Name)
 		}
 	}
 }

--- a/go/schema/schema_test.go
+++ b/go/schema/schema_test.go
@@ -1,0 +1,32 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchema(t *testing.T) {
+	si, err := Load("../testdata/sakila-schema-info.json")
+	require.NoError(t, err)
+	require.NotNil(t, si)
+	require.NotEmpty(t, si.Tables)
+	require.Equal(t, 16, len(si.Tables))
+	var tables []string
+	for _, table := range si.Tables {
+		tables = append(tables, table.Name)
+	}
+	require.Contains(t, tables, "actor")
+	require.NotContains(t, tables, "foo")
+	for _, table := range si.Tables {
+		require.NotEmpty(t, table.Name)
+		switch table.Name {
+		case "language":
+			require.Equal(t, 6, table.Rows)
+		case "film":
+			require.Equal(t, 1000, table.Rows)
+		default:
+			require.Greater(t, table.Rows, 0, "table %s has no rows", table.Name)
+		}
+	}
+}

--- a/go/summarize/summarize-keys.go
+++ b/go/summarize/summarize-keys.go
@@ -18,7 +18,6 @@ package summarize
 
 import (
 	"fmt"
-	"github.com/vitessio/vt/go/schema"
 	"io"
 	"iter"
 	"maps"
@@ -26,6 +25,8 @@ import (
 	"sort"
 	"strconv"
 	"time"
+
+	"github.com/vitessio/vt/go/schema"
 
 	"vitess.io/vitess/go/slice"
 	"vitess.io/vitess/go/vt/sqlparser"

--- a/go/summarize/summarize-keys.go
+++ b/go/summarize/summarize-keys.go
@@ -26,14 +26,13 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/vitessio/vt/go/schema"
-
 	"vitess.io/vitess/go/slice"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators"
 
 	"github.com/vitessio/vt/go/keys"
 	"github.com/vitessio/vt/go/markdown"
+	"github.com/vitessio/vt/go/schema"
 )
 
 const HotQueryCount = 10
@@ -168,7 +167,7 @@ func printKeysSummary(out io.Writer, file readingSummary, now time.Time, hotMetr
 	md.Printf(msg, now.Format(time.DateTime), file.Name)
 	metricReader := getMetricForHotness(hotMetric)
 
-	var schemaInfo *schema.SchemaInfo
+	var schemaInfo *schema.Info
 	if schemaInfoPath != "" {
 		schemaInfo, err = schema.Load(schemaInfoPath)
 		if err != nil {
@@ -420,7 +419,7 @@ func makeKey(lhs, rhs operators.Column) graphKey {
 	return graphKey{rhs.Table, lhs.Table}
 }
 
-func summarizeKeysQueries(queries *keys.Output, metricReader getMetric, schemaInfo *schema.SchemaInfo) Summary {
+func summarizeKeysQueries(queries *keys.Output, metricReader getMetric, schemaInfo *schema.Info) Summary {
 	tableSummaries := make(map[string]*TableSummary)
 	tableUsageWriteCounts := make(map[string]int)
 	tableUsageReadCounts := make(map[string]int)

--- a/go/summarize/summarize-keys.go
+++ b/go/summarize/summarize-keys.go
@@ -18,6 +18,7 @@ package summarize
 
 import (
 	"fmt"
+	"github.com/vitessio/vt/go/schema"
 	"io"
 	"iter"
 	"maps"
@@ -62,6 +63,7 @@ type (
 		Columns         map[ColumnInformation]ColumnUsage
 		JoinPredicates  []operators.JoinPredicate
 		Failed          bool
+		RowCount        int
 	}
 
 	FailuresSummary struct {
@@ -152,7 +154,8 @@ func (ts TableSummary) UseCount() int {
 
 // printKeysSummary goes over all the analysed queries, gathers information about column usage per table,
 // and prints this summary information to the output.
-func printKeysSummary(out io.Writer, file readingSummary, now time.Time, hotMetric string) {
+func printKeysSummary(out io.Writer, file readingSummary, now time.Time, hotMetric, schemaInfoPath string) {
+	var err error
 	md := &markdown.MarkDown{}
 
 	msg := `# Query Analysis Report
@@ -163,14 +166,22 @@ func printKeysSummary(out io.Writer, file readingSummary, now time.Time, hotMetr
 `
 	md.Printf(msg, now.Format(time.DateTime), file.Name)
 	metricReader := getMetricForHotness(hotMetric)
-	summary := summarizeKeysQueries(file.AnalysedQueries, metricReader)
+
+	var schemaInfo *schema.SchemaInfo
+	if schemaInfoPath != "" {
+		schemaInfo, err = schema.Load(schemaInfoPath)
+		if err != nil {
+			panic(err)
+		}
+	}
+	summary := summarizeKeysQueries(file.AnalysedQueries, metricReader, schemaInfo)
 
 	renderHotQueries(md, summary.hotQueries, metricReader)
 	renderTableUsage(summary.tables, md)
 	renderTablesJoined(md, file.AnalysedQueries)
 	renderFailures(md, summary.failures)
 
-	_, err := md.WriteTo(out)
+	_, err = md.WriteTo(out)
 	if err != nil {
 		panic(err)
 	}
@@ -276,13 +287,14 @@ func renderTableUsage(tableSummaries []TableSummary, md *markdown.MarkDown) {
 }
 
 func renderTableOverview(md *markdown.MarkDown, tableSummaries []TableSummary) {
-	headers := []string{"Table Name", "Reads", "Writes"}
+	headers := []string{"Table Name", "Reads", "Writes", "Number of Rows"}
 	var rows [][]string
 	for _, summary := range tableSummaries {
 		rows = append(rows, []string{
 			summary.Table,
 			strconv.Itoa(summary.ReadQueryCount),
 			strconv.Itoa(summary.WriteQueryCount),
+			strconv.Itoa(summary.RowCount),
 		})
 	}
 	md.PrintTable(headers, rows)
@@ -407,7 +419,7 @@ func makeKey(lhs, rhs operators.Column) graphKey {
 	return graphKey{rhs.Table, lhs.Table}
 }
 
-func summarizeKeysQueries(queries *keys.Output, metricReader getMetric) Summary {
+func summarizeKeysQueries(queries *keys.Output, metricReader getMetric, schemaInfo *schema.SchemaInfo) Summary {
 	tableSummaries := make(map[string]*TableSummary)
 	tableUsageWriteCounts := make(map[string]int)
 	tableUsageReadCounts := make(map[string]int)
@@ -419,11 +431,23 @@ func summarizeKeysQueries(queries *keys.Output, metricReader getMetric) Summary 
 		checkQueryForHotness(&hotQueries, query, metricReader)
 	}
 
+	tableRows := make(map[string]int)
+	if schemaInfo != nil {
+		for _, ti := range schemaInfo.Tables {
+			tableRows[ti.Name] = ti.Rows
+		}
+	}
+
 	// Second pass: calculate percentages
 	for _, summary := range tableSummaries {
 		summary.ReadQueryCount = tableUsageReadCounts[summary.Table]
 		summary.WriteQueryCount = tableUsageWriteCounts[summary.Table]
 		count := summary.ReadQueryCount + summary.WriteQueryCount
+		if schemaInfo != nil {
+			if rowCount, ok := tableRows[summary.Table]; ok {
+				summary.RowCount = rowCount
+			}
+		}
 		countF := float64(count)
 		for colName, usage := range summary.Columns {
 			usage.Percentage = (float64(usage.Count) / countF) * 100

--- a/go/summarize/summarize-keys_test.go
+++ b/go/summarize/summarize-keys_test.go
@@ -71,7 +71,8 @@ func TestSummarizeKeysFile(t *testing.T) {
 	require.NoError(t, err)
 	sb := &strings.Builder{}
 	now := time.Date(2024, time.January, 1, 1, 2, 3, 0, time.UTC)
-	printKeysSummary(sb, file, now, "")
+
+	printKeysSummary(sb, file, now, "", "../testdata/keys-schema-info.json")
 	expected, err := os.ReadFile("../testdata/keys-summary.md")
 	require.NoError(t, err)
 	assert.Equal(t, string(expected), sb.String())
@@ -95,7 +96,7 @@ func TestSummarizeKeysWithHotnessFile(t *testing.T) {
 			require.NoError(t, err)
 			sb := &strings.Builder{}
 			now := time.Date(2024, time.January, 1, 1, 2, 3, 0, time.UTC)
-			printKeysSummary(sb, file, now, metric)
+			printKeysSummary(sb, file, now, metric, "../testdata/bigger_slow_query_schema_info.json")
 			expected, err := os.ReadFile(fmt.Sprintf("../testdata/bigger_slow_log_%s.md", metric))
 			require.NoError(t, err)
 			assert.Equal(t, string(expected), sb.String())

--- a/go/summarize/summarize.go
+++ b/go/summarize/summarize.go
@@ -39,7 +39,7 @@ type (
 	}
 )
 
-func Run(files []string, hotMetric string) {
+func Run(files []string, hotMetric, schemaInfoPath string) {
 	traces := make([]readingSummary, len(files))
 	var err error
 	for i, arg := range files {
@@ -62,7 +62,7 @@ func Run(files []string, hotMetric string) {
 	if firstTrace.AnalysedQueries == nil {
 		printTraceSummary(os.Stdout, terminalWidth(), highlightQuery, firstTrace)
 	} else {
-		printKeysSummary(os.Stdout, firstTrace, time.Now(), hotMetric)
+		printKeysSummary(os.Stdout, firstTrace, time.Now(), hotMetric, schemaInfoPath)
 	}
 }
 

--- a/go/summarize/summarize.go
+++ b/go/summarize/summarize.go
@@ -39,10 +39,25 @@ type (
 	}
 )
 
-func Run(files []string, hotMetric, schemaInfoPath string) {
-	traces := make([]readingSummary, len(files))
+func Run(files []string, hotMetric string) {
+	var traceFiles []string
+	var dbInfoPath string
+	// todo: add file types for other json types. Right now just checks for dbinfo files, else defaults
+	for _, file := range files {
+		typ, _ := getFileType(file)
+		switch typ {
+		case dbInfoFile:
+			fmt.Printf("dbinfo file: %s\n", file)
+			dbInfoPath = file
+		default:
+			fmt.Printf("trace file: %s\n", file)
+			traceFiles = append(traceFiles, file)
+		}
+	}
+
+	traces := make([]readingSummary, len(traceFiles))
 	var err error
-	for i, arg := range files {
+	for i, arg := range traceFiles {
 		traces[i], err = readTraceFile(arg)
 		if err != nil {
 			exit(err.Error())
@@ -62,7 +77,7 @@ func Run(files []string, hotMetric, schemaInfoPath string) {
 	if firstTrace.AnalysedQueries == nil {
 		printTraceSummary(os.Stdout, terminalWidth(), highlightQuery, firstTrace)
 	} else {
-		printKeysSummary(os.Stdout, firstTrace, time.Now(), hotMetric, schemaInfoPath)
+		printKeysSummary(os.Stdout, firstTrace, time.Now(), hotMetric, dbInfoPath)
 	}
 }
 

--- a/go/summarize/utils.go
+++ b/go/summarize/utils.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package summarize
 
 import (

--- a/go/summarize/utils.go
+++ b/go/summarize/utils.go
@@ -1,0 +1,79 @@
+package summarize
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+)
+
+type fileType int
+
+const (
+	unknownFile fileType = iota
+	traceFile
+	keysFile
+	dbInfoFile
+)
+
+var fileTypeMap = map[string]fileType{
+	"trace":  traceFile,
+	"keys":   keysFile,
+	"dbinfo": dbInfoFile,
+}
+
+// getFileType reads the first key-value pair from a JSON file and returns the type of the file
+// Note:
+func getFileType(filename string) (fileType, error) {
+	// read json file
+	file, err := os.Open(filename)
+	if err != nil {
+		return unknownFile, errors.New(fmt.Sprintf("error opening file: %v", err))
+	}
+	defer file.Close()
+
+	decoder := json.NewDecoder(file)
+
+	token, err := decoder.Token()
+	if err != nil {
+		return unknownFile, errors.New(fmt.Sprintf("Error reading token: %v", err))
+	}
+
+	// Ensure the token is the start of an object
+	if delim, ok := token.(json.Delim); !ok || delim != '{' {
+		return unknownFile, errors.New(fmt.Sprintf("Expected start of object '{'"))
+	}
+
+	// Read the key-value pairs
+	for decoder.More() {
+		// Read the key
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return unknownFile, errors.New(fmt.Sprintf("Error reading key token: %v", err))
+		}
+
+		key, ok := keyToken.(string)
+		if !ok {
+			return unknownFile, errors.New(fmt.Sprintf("Expected key to be a string: %s", keyToken))
+		}
+
+		// Read the value
+		valueToken, err := decoder.Token()
+		if err != nil {
+			return unknownFile, errors.New(fmt.Sprintf("Error reading value token: %v", err))
+		}
+
+		// Check if the key is "FileType"
+		if key == "FileType" {
+			if fileType, ok := fileTypeMap[valueToken.(string)]; ok {
+				return fileType, nil
+			} else {
+				return unknownFile, errors.New(fmt.Sprintf("Unknown FileType: %s", valueToken))
+			}
+		} else {
+			// Currently we expect the first key to be FileType, for optimization reasons
+			return unknownFile, nil
+		}
+	}
+	return unknownFile, nil
+}

--- a/go/summarize/utils.go
+++ b/go/summarize/utils.go
@@ -41,7 +41,6 @@ var fileTypeMap = map[string]fileType{
 // getFileType reads the first key-value pair from a JSON file and returns the type of the file
 // Note:
 func getFileType(filename string) (fileType, error) {
-	// read json file
 	file, err := os.Open(filename)
 	if err != nil {
 		return unknownFile, errors.New(fmt.Sprintf("error opening file: %v", err))
@@ -55,14 +54,11 @@ func getFileType(filename string) (fileType, error) {
 		return unknownFile, errors.New(fmt.Sprintf("Error reading token: %v", err))
 	}
 
-	// Ensure the token is the start of an object
 	if delim, ok := token.(json.Delim); !ok || delim != '{' {
 		return unknownFile, errors.New(fmt.Sprintf("Expected start of object '{'"))
 	}
 
-	// Read the key-value pairs
 	for decoder.More() {
-		// Read the key
 		keyToken, err := decoder.Token()
 		if err != nil {
 			return unknownFile, errors.New(fmt.Sprintf("Error reading key token: %v", err))
@@ -73,14 +69,12 @@ func getFileType(filename string) (fileType, error) {
 			return unknownFile, errors.New(fmt.Sprintf("Expected key to be a string: %s", keyToken))
 		}
 
-		// Read the value
 		valueToken, err := decoder.Token()
 		if err != nil {
 			return unknownFile, errors.New(fmt.Sprintf("Error reading value token: %v", err))
 		}
 
-		// Check if the key is "FileType"
-		if key == "FileType" {
+		if key == "fileType" {
 			if fileType, ok := fileTypeMap[valueToken.(string)]; ok {
 				return fileType, nil
 			} else {

--- a/go/summarize/utils_test.go
+++ b/go/summarize/utils_test.go
@@ -1,0 +1,45 @@
+package summarize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test utils getFileType function
+func TestGetFileType(t *testing.T) {
+	type testCase struct {
+		filename      string
+		expectedType  fileType
+		expectedError string
+	}
+	testCases := []testCase{
+		{
+			filename:     "../testdata/keys-log.json",
+			expectedType: unknownFile,
+		},
+		{
+			filename:     "../testdata/sakila-schema-info.json",
+			expectedType: dbInfoFile,
+		},
+		{
+			filename:      "../testdata/mysql.query.log",
+			expectedType:  unknownFile,
+			expectedError: "Error reading token",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.filename, func(t *testing.T) {
+			ft, err := getFileType(tc.filename)
+			if tc.expectedError != "" {
+				require.Error(t, err)
+			}
+			if err != nil {
+				require.Contains(t, err.Error(), tc.expectedError)
+			}
+			if ft != tc.expectedType {
+				t.Errorf("Expected type: %v, got: %v", tc.expectedType, ft)
+			}
+		})
+	}
+}

--- a/go/summarize/utils_test.go
+++ b/go/summarize/utils_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package summarize
 
 import (

--- a/go/summarize/utils_test.go
+++ b/go/summarize/utils_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package summarize
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
 )

--- a/go/summarize/utils_test.go
+++ b/go/summarize/utils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package summarize
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -48,14 +49,9 @@ func TestGetFileType(t *testing.T) {
 		t.Run(tc.filename, func(t *testing.T) {
 			ft, err := getFileType(tc.filename)
 			if tc.expectedError != "" {
-				require.Error(t, err)
+				require.ErrorContains(t, err, tc.expectedError)
 			}
-			if err != nil {
-				require.Contains(t, err.Error(), tc.expectedError)
-			}
-			if ft != tc.expectedType {
-				t.Errorf("Expected type: %v, got: %v", tc.expectedType, ft)
-			}
+			assert.Equal(t, tc.expectedType, ft)
 		})
 	}
 }

--- a/go/testdata/keys-schema-info.json
+++ b/go/testdata/keys-schema-info.json
@@ -1,0 +1,36 @@
+{
+  "Tables": [
+    {
+      "Name": "region",
+      "Rows": 20
+    },
+    {
+      "Name": "nation",
+      "Rows": 150
+    },
+    {
+      "Name": "supplier",
+      "Rows": 318
+    },
+    {
+      "Name": "part",
+      "Rows": 2761
+    },
+    {
+      "Name": "partsupp",
+      "Rows": 32381
+    },
+    {
+      "Name": "customer",
+      "Rows": 280000
+    },
+    {
+      "Name": "orders",
+      "Rows": 12047555
+    },
+    {
+      "Name": "lineitem",
+      "Rows": 42047555
+    }
+  ]
+}

--- a/go/testdata/keys-summary.md
+++ b/go/testdata/keys-summary.md
@@ -4,16 +4,16 @@
 **Analyzed File**: `../testdata/keys-log.json`
 
 ## Tables
-|Table Name|Reads|Writes|
-|---|---|---|
-|lineitem|17|1|
-|orders|11|1|
-|nation|10|1|
-|supplier|8|1|
-|customer|7|1|
-|part|5|1|
-|partsupp|4|1|
-|region|2|1|
+|Table Name|Reads|Writes|Number of Rows|
+|---|---|---|---|
+|lineitem|17|1|42047555|
+|orders|11|1|12047555|
+|nation|10|1|150|
+|supplier|8|1|318|
+|customer|7|1|280000|
+|part|5|1|2761|
+|partsupp|4|1|32381|
+|region|2|1|20|
 
 ### Column Usage
 #### Table: `lineitem` (17 reads and 1 writes)

--- a/go/testdata/sakila-schema-info.json
+++ b/go/testdata/sakila-schema-info.json
@@ -1,4 +1,5 @@
 {
+  "FileType": "dbinfo",
   "Tables": [
     {
       "Name": "actor",

--- a/go/testdata/sakila-schema-info.json
+++ b/go/testdata/sakila-schema-info.json
@@ -1,0 +1,69 @@
+{
+  "Tables": [
+    {
+      "Name": "actor",
+      "Rows": 200
+    },
+    {
+      "Name": "address",
+      "Rows": 603
+    },
+    {
+      "Name": "category",
+      "Rows": 16
+    },
+    {
+      "Name": "city",
+      "Rows": 600
+    },
+    {
+      "Name": "country",
+      "Rows": 109
+    },
+    {
+      "Name": "customer",
+      "Rows": 599
+    },
+    {
+      "Name": "film",
+      "Rows": 1000
+    },
+    {
+      "Name": "film_actor",
+      "Rows": 5462
+    },
+    {
+      "Name": "film_category",
+      "Rows": 1000
+    },
+    {
+      "Name": "film_text",
+      "Rows": 1000
+    },
+    {
+      "Name": "inventory",
+      "Rows": 4581
+    },
+    {
+      "Name": "language",
+      "Rows": 6
+    },
+    {
+      "Name": "payment",
+      "Rows": 16086
+    },
+    {
+      "Name": "rental",
+      "Rows": 15425
+    },
+    {
+      "Name": "staff",
+      "Rows": 2
+    },
+    {
+      "Name": "store",
+      "Rows": 2
+    }
+  ]
+}
+

--- a/go/testdata/sakila-schema-info.json
+++ b/go/testdata/sakila-schema-info.json
@@ -1,69 +1,69 @@
 {
-  "FileType": "dbinfo",
-  "Tables": [
+  "fileType": "dbinfo",
+  "tables": [
     {
-      "Name": "actor",
-      "Rows": 200
+      "name": "actor",
+      "rows": 200
     },
     {
-      "Name": "address",
-      "Rows": 603
+      "name": "address",
+      "rows": 603
     },
     {
-      "Name": "category",
-      "Rows": 16
+      "name": "category",
+      "rows": 16
     },
     {
-      "Name": "city",
-      "Rows": 600
+      "name": "city",
+      "rows": 600
     },
     {
-      "Name": "country",
-      "Rows": 109
+      "name": "country",
+      "rows": 109
     },
     {
-      "Name": "customer",
-      "Rows": 599
+      "name": "customer",
+      "rows": 599
     },
     {
-      "Name": "film",
-      "Rows": 1000
+      "name": "film",
+      "rows": 1000
     },
     {
-      "Name": "film_actor",
-      "Rows": 5462
+      "name": "film_actor",
+      "rows": 5462
     },
     {
-      "Name": "film_category",
-      "Rows": 1000
+      "name": "film_category",
+      "rows": 1000
     },
     {
-      "Name": "film_text",
-      "Rows": 1000
+      "name": "film_text",
+      "rows": 1000
     },
     {
-      "Name": "inventory",
-      "Rows": 4581
+      "name": "inventory",
+      "rows": 4581
     },
     {
-      "Name": "language",
-      "Rows": 6
+      "name": "language",
+      "rows": 6
     },
     {
-      "Name": "payment",
-      "Rows": 16086
+      "name": "payment",
+      "rows": 16086
     },
     {
-      "Name": "rental",
-      "Rows": 15425
+      "name": "rental",
+      "rows": 15425
     },
     {
-      "Name": "staff",
-      "Rows": 2
+      "name": "staff",
+      "rows": 2
     },
     {
-      "Name": "store",
-      "Rows": 2
+      "name": "store",
+      "rows": 2
     }
   ]
 }

--- a/go/testdata/sakila-schema.sql
+++ b/go/testdata/sakila-schema.sql
@@ -1,0 +1,688 @@
+# noinspection SqlNoDataSourceInspectionForFile
+
+-- Sakila Sample Database Schema
+-- Version 1.5
+
+-- Copyright (c) 2006, 2024, Oracle and/or its affiliates.
+
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are
+-- met:
+
+-- * Redistributions of source code must retain the above copyright notice,
+--   this list of conditions and the following disclaimer.
+-- * Redistributions in binary form must reproduce the above copyright
+--   notice, this list of conditions and the following disclaimer in the
+--   documentation and/or other materials provided with the distribution.
+-- * Neither the name of Oracle nor the names of its contributors may be used
+--   to endorse or promote products derived from this software without
+--   specific prior written permission.
+
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+-- IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+-- THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+-- PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+-- CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+-- EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+-- PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+-- PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+-- LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+-- NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+SET NAMES utf8mb4;
+SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='TRADITIONAL';
+
+DROP SCHEMA IF EXISTS sakila;
+CREATE SCHEMA sakila;
+USE sakila;
+
+--
+-- Table structure for table `actor`
+--
+
+CREATE TABLE actor (
+  actor_id SMALLINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  first_name VARCHAR(45) NOT NULL,
+  last_name VARCHAR(45) NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY  (actor_id),
+  KEY idx_actor_last_name (last_name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--
+-- Table structure for table `address`
+--
+
+CREATE TABLE address (
+  address_id SMALLINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  address VARCHAR(50) NOT NULL,
+  address2 VARCHAR(50) DEFAULT NULL,
+  district VARCHAR(20) NOT NULL,
+  city_id SMALLINT UNSIGNED NOT NULL,
+  postal_code VARCHAR(10) DEFAULT NULL,
+  phone VARCHAR(20) NOT NULL,
+  -- Add GEOMETRY column for MySQL 5.7.5 and higher
+  -- Also include SRID attribute for MySQL 8.0.3 and higher
+  /*!50705 location GEOMETRY */ /*!80003 SRID 0 */ /*!50705 NOT NULL,*/
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY  (address_id),
+  KEY idx_fk_city_id (city_id),
+  /*!50705 SPATIAL KEY `idx_location` (location),*/
+  CONSTRAINT `fk_address_city` FOREIGN KEY (city_id) REFERENCES city (city_id) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--
+-- Table structure for table `category`
+--
+
+CREATE TABLE category (
+  category_id TINYINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  name VARCHAR(25) NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY  (category_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--
+-- Table structure for table `city`
+--
+
+CREATE TABLE city (
+  city_id SMALLINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  city VARCHAR(50) NOT NULL,
+  country_id SMALLINT UNSIGNED NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY  (city_id),
+  KEY idx_fk_country_id (country_id),
+  CONSTRAINT `fk_city_country` FOREIGN KEY (country_id) REFERENCES country (country_id) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--
+-- Table structure for table `country`
+--
+
+CREATE TABLE country (
+  country_id SMALLINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  country VARCHAR(50) NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY  (country_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--
+-- Table structure for table `customer`
+--
+
+CREATE TABLE customer (
+  customer_id SMALLINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  store_id TINYINT UNSIGNED NOT NULL,
+  first_name VARCHAR(45) NOT NULL,
+  last_name VARCHAR(45) NOT NULL,
+  email VARCHAR(50) DEFAULT NULL,
+  address_id SMALLINT UNSIGNED NOT NULL,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  create_date DATETIME NOT NULL,
+  last_update TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY  (customer_id),
+  KEY idx_fk_store_id (store_id),
+  KEY idx_fk_address_id (address_id),
+  KEY idx_last_name (last_name),
+  CONSTRAINT fk_customer_address FOREIGN KEY (address_id) REFERENCES address (address_id) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT fk_customer_store FOREIGN KEY (store_id) REFERENCES store (store_id) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--
+-- Table structure for table `film`
+--
+
+CREATE TABLE film (
+  film_id SMALLINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  title VARCHAR(128) NOT NULL,
+  description TEXT DEFAULT NULL,
+  release_year YEAR DEFAULT NULL,
+  language_id TINYINT UNSIGNED NOT NULL,
+  original_language_id TINYINT UNSIGNED DEFAULT NULL,
+  rental_duration TINYINT UNSIGNED NOT NULL DEFAULT 3,
+  rental_rate DECIMAL(4,2) NOT NULL DEFAULT 4.99,
+  length SMALLINT UNSIGNED DEFAULT NULL,
+  replacement_cost DECIMAL(5,2) NOT NULL DEFAULT 19.99,
+  rating ENUM('G','PG','PG-13','R','NC-17') DEFAULT 'G',
+  special_features SET('Trailers','Commentaries','Deleted Scenes','Behind the Scenes') DEFAULT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY  (film_id),
+  KEY idx_title (title),
+  KEY idx_fk_language_id (language_id),
+  KEY idx_fk_original_language_id (original_language_id),
+  CONSTRAINT fk_film_language FOREIGN KEY (language_id) REFERENCES language (language_id) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT fk_film_language_original FOREIGN KEY (original_language_id) REFERENCES language (language_id) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--
+-- Table structure for table `film_actor`
+--
+
+CREATE TABLE film_actor (
+  actor_id SMALLINT UNSIGNED NOT NULL,
+  film_id SMALLINT UNSIGNED NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY  (actor_id,film_id),
+  KEY idx_fk_film_id (`film_id`),
+  CONSTRAINT fk_film_actor_actor FOREIGN KEY (actor_id) REFERENCES actor (actor_id) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT fk_film_actor_film FOREIGN KEY (film_id) REFERENCES film (film_id) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--
+-- Table structure for table `film_category`
+--
+
+CREATE TABLE film_category (
+  film_id SMALLINT UNSIGNED NOT NULL,
+  category_id TINYINT UNSIGNED NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (film_id, category_id),
+  CONSTRAINT fk_film_category_film FOREIGN KEY (film_id) REFERENCES film (film_id) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT fk_film_category_category FOREIGN KEY (category_id) REFERENCES category (category_id) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--
+-- Table structure for table `film_text`
+-- 
+-- InnoDB added FULLTEXT support in 5.6.10. If you use an
+-- earlier version, then consider upgrading (recommended) or 
+-- changing InnoDB to MyISAM as the film_text engine
+--
+
+-- Use InnoDB for film_text as of 5.6.10, MyISAM prior to 5.6.10.
+SET @old_default_storage_engine = @@default_storage_engine;
+SET @@default_storage_engine = 'MyISAM';
+/*!50610 SET @@default_storage_engine = 'InnoDB'*/;
+
+CREATE TABLE film_text (
+  film_id SMALLINT UNSIGNED NOT NULL,
+  title VARCHAR(255) NOT NULL,
+  description TEXT,
+  PRIMARY KEY  (film_id),
+  FULLTEXT KEY idx_title_description (title,description)
+) DEFAULT CHARSET=utf8mb4;
+
+SET @@default_storage_engine = @old_default_storage_engine;
+
+--
+-- Triggers for loading film_text from film
+--
+
+DELIMITER ;;
+CREATE TRIGGER `ins_film` AFTER INSERT ON `film` FOR EACH ROW BEGIN
+    INSERT INTO film_text (film_id, title, description)
+        VALUES (new.film_id, new.title, new.description);
+  END;;
+
+
+CREATE TRIGGER `upd_film` AFTER UPDATE ON `film` FOR EACH ROW BEGIN
+    IF (old.title != new.title) OR (old.description != new.description) OR (old.film_id != new.film_id)
+    THEN
+        UPDATE film_text
+            SET title=new.title,
+                description=new.description,
+                film_id=new.film_id
+        WHERE film_id=old.film_id;
+    END IF;
+  END;;
+
+
+CREATE TRIGGER `del_film` AFTER DELETE ON `film` FOR EACH ROW BEGIN
+    DELETE FROM film_text WHERE film_id = old.film_id;
+  END;;
+
+DELIMITER ;
+
+--
+-- Table structure for table `inventory`
+--
+
+CREATE TABLE inventory (
+  inventory_id MEDIUMINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  film_id SMALLINT UNSIGNED NOT NULL,
+  store_id TINYINT UNSIGNED NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY  (inventory_id),
+  KEY idx_fk_film_id (film_id),
+  KEY idx_store_id_film_id (store_id,film_id),
+  CONSTRAINT fk_inventory_store FOREIGN KEY (store_id) REFERENCES store (store_id) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT fk_inventory_film FOREIGN KEY (film_id) REFERENCES film (film_id) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--
+-- Table structure for table `language`
+--
+
+CREATE TABLE language (
+  language_id TINYINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  name CHAR(20) NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (language_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--
+-- Table structure for table `payment`
+--
+
+CREATE TABLE payment (
+  payment_id SMALLINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  customer_id SMALLINT UNSIGNED NOT NULL,
+  staff_id TINYINT UNSIGNED NOT NULL,
+  rental_id INT DEFAULT NULL,
+  amount DECIMAL(5,2) NOT NULL,
+  payment_date DATETIME NOT NULL,
+  last_update TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY  (payment_id),
+  KEY idx_fk_staff_id (staff_id),
+  KEY idx_fk_customer_id (customer_id),
+  CONSTRAINT fk_payment_rental FOREIGN KEY (rental_id) REFERENCES rental (rental_id) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT fk_payment_customer FOREIGN KEY (customer_id) REFERENCES customer (customer_id) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT fk_payment_staff FOREIGN KEY (staff_id) REFERENCES staff (staff_id) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+
+--
+-- Table structure for table `rental`
+--
+
+CREATE TABLE rental (
+  rental_id INT NOT NULL AUTO_INCREMENT,
+  rental_date DATETIME NOT NULL,
+  inventory_id MEDIUMINT UNSIGNED NOT NULL,
+  customer_id SMALLINT UNSIGNED NOT NULL,
+  return_date DATETIME DEFAULT NULL,
+  staff_id TINYINT UNSIGNED NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (rental_id),
+  UNIQUE KEY  (rental_date,inventory_id,customer_id),
+  KEY idx_fk_inventory_id (inventory_id),
+  KEY idx_fk_customer_id (customer_id),
+  KEY idx_fk_staff_id (staff_id),
+  CONSTRAINT fk_rental_staff FOREIGN KEY (staff_id) REFERENCES staff (staff_id) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT fk_rental_inventory FOREIGN KEY (inventory_id) REFERENCES inventory (inventory_id) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT fk_rental_customer FOREIGN KEY (customer_id) REFERENCES customer (customer_id) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--
+-- Table structure for table `staff`
+--
+
+CREATE TABLE staff (
+  staff_id TINYINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  first_name VARCHAR(45) NOT NULL,
+  last_name VARCHAR(45) NOT NULL,
+  address_id SMALLINT UNSIGNED NOT NULL,
+  picture BLOB DEFAULT NULL,
+  email VARCHAR(50) DEFAULT NULL,
+  store_id TINYINT UNSIGNED NOT NULL,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  username VARCHAR(16) NOT NULL,
+  password VARCHAR(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY  (staff_id),
+  KEY idx_fk_store_id (store_id),
+  KEY idx_fk_address_id (address_id),
+  CONSTRAINT fk_staff_store FOREIGN KEY (store_id) REFERENCES store (store_id) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT fk_staff_address FOREIGN KEY (address_id) REFERENCES address (address_id) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--
+-- Table structure for table `store`
+--
+
+CREATE TABLE store (
+  store_id TINYINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  manager_staff_id TINYINT UNSIGNED NOT NULL,
+  address_id SMALLINT UNSIGNED NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY  (store_id),
+  UNIQUE KEY idx_unique_manager (manager_staff_id),
+  KEY idx_fk_address_id (address_id),
+  CONSTRAINT fk_store_staff FOREIGN KEY (manager_staff_id) REFERENCES staff (staff_id) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT fk_store_address FOREIGN KEY (address_id) REFERENCES address (address_id) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--
+-- View structure for view `customer_list`
+--
+
+CREATE VIEW customer_list
+AS
+SELECT cu.customer_id AS ID, CONCAT(cu.first_name, _utf8mb4' ', cu.last_name) AS name, a.address AS address, a.postal_code AS `zip code`,
+	a.phone AS phone, city.city AS city, country.country AS country, IF(cu.active, _utf8mb4'active',_utf8mb4'') AS notes, cu.store_id AS SID
+FROM customer AS cu JOIN address AS a ON cu.address_id = a.address_id JOIN city ON a.city_id = city.city_id
+	JOIN country ON city.country_id = country.country_id;
+
+--
+-- View structure for view `film_list`
+--
+
+CREATE VIEW film_list
+AS
+SELECT film.film_id AS FID, film.title AS title, film.description AS description, category.name AS category, film.rental_rate AS price,
+	film.length AS length, film.rating AS rating, GROUP_CONCAT(CONCAT(actor.first_name, _utf8mb4' ', actor.last_name) SEPARATOR ', ') AS actors
+FROM film LEFT JOIN film_category ON film_category.film_id = film.film_id
+LEFT JOIN category ON category.category_id = film_category.category_id LEFT
+JOIN film_actor ON film.film_id = film_actor.film_id LEFT JOIN actor ON
+  film_actor.actor_id = actor.actor_id
+GROUP BY film.film_id, category.name;
+
+--
+-- View structure for view `nicer_but_slower_film_list`
+--
+
+CREATE VIEW nicer_but_slower_film_list
+AS
+SELECT film.film_id AS FID, film.title AS title, film.description AS description, category.name AS category, film.rental_rate AS price,
+	film.length AS length, film.rating AS rating, GROUP_CONCAT(CONCAT(CONCAT(UCASE(SUBSTR(actor.first_name,1,1)),
+	LCASE(SUBSTR(actor.first_name,2,LENGTH(actor.first_name))),_utf8mb4' ',CONCAT(UCASE(SUBSTR(actor.last_name,1,1)),
+	LCASE(SUBSTR(actor.last_name,2,LENGTH(actor.last_name)))))) SEPARATOR ', ') AS actors
+FROM film LEFT JOIN film_category ON film_category.film_id = film.film_id
+LEFT JOIN category ON category.category_id = film_category.category_id LEFT
+JOIN film_actor ON film.film_id = film_actor.film_id LEFT JOIN actor ON
+  film_actor.actor_id = actor.actor_id
+GROUP BY film.film_id, category.name;
+
+--
+-- View structure for view `staff_list`
+--
+
+CREATE VIEW staff_list
+AS
+SELECT s.staff_id AS ID, CONCAT(s.first_name, _utf8mb4' ', s.last_name) AS name, a.address AS address, a.postal_code AS `zip code`, a.phone AS phone,
+	city.city AS city, country.country AS country, s.store_id AS SID
+FROM staff AS s JOIN address AS a ON s.address_id = a.address_id JOIN city ON a.city_id = city.city_id
+	JOIN country ON city.country_id = country.country_id;
+
+--
+-- View structure for view `sales_by_store`
+--
+
+CREATE VIEW sales_by_store
+AS
+SELECT
+CONCAT(c.city, _utf8mb4',', cy.country) AS store
+, CONCAT(m.first_name, _utf8mb4' ', m.last_name) AS manager
+, SUM(p.amount) AS total_sales
+FROM payment AS p
+INNER JOIN rental AS r ON p.rental_id = r.rental_id
+INNER JOIN inventory AS i ON r.inventory_id = i.inventory_id
+INNER JOIN store AS s ON i.store_id = s.store_id
+INNER JOIN address AS a ON s.address_id = a.address_id
+INNER JOIN city AS c ON a.city_id = c.city_id
+INNER JOIN country AS cy ON c.country_id = cy.country_id
+INNER JOIN staff AS m ON s.manager_staff_id = m.staff_id
+GROUP BY s.store_id
+ORDER BY cy.country, c.city;
+
+--
+-- View structure for view `sales_by_film_category`
+--
+-- Note that total sales will add up to >100% because
+-- some titles belong to more than 1 category
+--
+
+CREATE VIEW sales_by_film_category
+AS
+SELECT
+c.name AS category
+, SUM(p.amount) AS total_sales
+FROM payment AS p
+INNER JOIN rental AS r ON p.rental_id = r.rental_id
+INNER JOIN inventory AS i ON r.inventory_id = i.inventory_id
+INNER JOIN film AS f ON i.film_id = f.film_id
+INNER JOIN film_category AS fc ON f.film_id = fc.film_id
+INNER JOIN category AS c ON fc.category_id = c.category_id
+GROUP BY c.name
+ORDER BY total_sales DESC;
+
+--
+-- View structure for view `actor_info`
+--
+
+CREATE DEFINER=CURRENT_USER SQL SECURITY INVOKER VIEW actor_info
+AS
+SELECT
+a.actor_id,
+a.first_name,
+a.last_name,
+GROUP_CONCAT(DISTINCT CONCAT(c.name, ': ',
+		(SELECT GROUP_CONCAT(f.title ORDER BY f.title SEPARATOR ', ')
+                    FROM sakila.film f
+                    INNER JOIN sakila.film_category fc
+                      ON f.film_id = fc.film_id
+                    INNER JOIN sakila.film_actor fa
+                      ON f.film_id = fa.film_id
+                    WHERE fc.category_id = c.category_id
+                    AND fa.actor_id = a.actor_id
+                 )
+             )
+             ORDER BY c.name SEPARATOR '; ')
+AS film_info
+FROM sakila.actor a
+LEFT JOIN sakila.film_actor fa
+  ON a.actor_id = fa.actor_id
+LEFT JOIN sakila.film_category fc
+  ON fa.film_id = fc.film_id
+LEFT JOIN sakila.category c
+  ON fc.category_id = c.category_id
+GROUP BY a.actor_id, a.first_name, a.last_name;
+
+--
+-- Procedure structure for procedure `rewards_report`
+--
+
+DELIMITER //
+
+CREATE PROCEDURE rewards_report (
+    IN min_monthly_purchases TINYINT UNSIGNED
+    , IN min_dollar_amount_purchased DECIMAL(10,2)
+    , OUT count_rewardees INT
+)
+LANGUAGE SQL
+NOT DETERMINISTIC
+READS SQL DATA
+SQL SECURITY DEFINER
+COMMENT 'Provides a customizable report on best customers'
+proc: BEGIN
+
+    DECLARE last_month_start DATE;
+    DECLARE last_month_end DATE;
+
+    /* Some sanity checks... */
+    IF min_monthly_purchases = 0 THEN
+        SELECT 'Minimum monthly purchases parameter must be > 0';
+        LEAVE proc;
+    END IF;
+    IF min_dollar_amount_purchased = 0.00 THEN
+        SELECT 'Minimum monthly dollar amount purchased parameter must be > $0.00';
+        LEAVE proc;
+    END IF;
+
+    /* Determine start and end time periods */
+    SET last_month_start = DATE_SUB(CURRENT_DATE(), INTERVAL 1 MONTH);
+    SET last_month_start = STR_TO_DATE(CONCAT(YEAR(last_month_start),'-',MONTH(last_month_start),'-01'),'%Y-%m-%d');
+    SET last_month_end = LAST_DAY(last_month_start);
+
+    /*
+        Create a temporary storage area for
+        Customer IDs.
+    */
+    CREATE TEMPORARY TABLE tmpCustomer (customer_id SMALLINT UNSIGNED NOT NULL PRIMARY KEY);
+
+    /*
+        Find all customers meeting the
+        monthly purchase requirements
+    */
+    INSERT INTO tmpCustomer (customer_id)
+    SELECT p.customer_id
+    FROM payment AS p
+    WHERE DATE(p.payment_date) BETWEEN last_month_start AND last_month_end
+    GROUP BY customer_id
+    HAVING SUM(p.amount) > min_dollar_amount_purchased
+    AND COUNT(customer_id) > min_monthly_purchases;
+
+    /* Populate OUT parameter with count of found customers */
+    SELECT COUNT(*) FROM tmpCustomer INTO count_rewardees;
+
+    /*
+        Output ALL customer information of matching rewardees.
+        Customize output as needed.
+    */
+    SELECT c.*
+    FROM tmpCustomer AS t
+    INNER JOIN customer AS c ON t.customer_id = c.customer_id;
+
+    /* Clean up */
+    DROP TABLE tmpCustomer;
+END //
+
+DELIMITER ;
+
+DELIMITER $$
+
+CREATE FUNCTION get_customer_balance(p_customer_id INT, p_effective_date DATETIME) RETURNS DECIMAL(5,2)
+    DETERMINISTIC
+    READS SQL DATA
+BEGIN
+
+       #OK, WE NEED TO CALCULATE THE CURRENT BALANCE GIVEN A CUSTOMER_ID AND A DATE
+       #THAT WE WANT THE BALANCE TO BE EFFECTIVE FOR. THE BALANCE IS:
+       #   1) RENTAL FEES FOR ALL PREVIOUS RENTALS
+       #   2) ONE DOLLAR FOR EVERY DAY THE PREVIOUS RENTALS ARE OVERDUE
+       #   3) IF A FILM IS MORE THAN RENTAL_DURATION * 2 OVERDUE, CHARGE THE REPLACEMENT_COST
+       #   4) SUBTRACT ALL PAYMENTS MADE BEFORE THE DATE SPECIFIED
+
+  DECLARE v_rentfees DECIMAL(5,2); #FEES PAID TO RENT THE VIDEOS INITIALLY
+  DECLARE v_overfees INTEGER;      #LATE FEES FOR PRIOR RENTALS
+  DECLARE v_payments DECIMAL(5,2); #SUM OF PAYMENTS MADE PREVIOUSLY
+
+  SELECT IFNULL(SUM(film.rental_rate),0) INTO v_rentfees
+    FROM film, inventory, rental
+    WHERE film.film_id = inventory.film_id
+      AND inventory.inventory_id = rental.inventory_id
+      AND rental.rental_date <= p_effective_date
+      AND rental.customer_id = p_customer_id;
+
+  SELECT IFNULL(SUM(IF((TO_DAYS(rental.return_date) - TO_DAYS(rental.rental_date)) > film.rental_duration,
+        ((TO_DAYS(rental.return_date) - TO_DAYS(rental.rental_date)) - film.rental_duration),0)),0) INTO v_overfees
+    FROM rental, inventory, film
+    WHERE film.film_id = inventory.film_id
+      AND inventory.inventory_id = rental.inventory_id
+      AND rental.rental_date <= p_effective_date
+      AND rental.customer_id = p_customer_id;
+
+
+  SELECT IFNULL(SUM(payment.amount),0) INTO v_payments
+    FROM payment
+
+    WHERE payment.payment_date <= p_effective_date
+    AND payment.customer_id = p_customer_id;
+
+  RETURN v_rentfees + v_overfees - v_payments;
+END $$
+
+DELIMITER ;
+
+DELIMITER $$
+
+CREATE PROCEDURE film_in_stock(IN p_film_id INT, IN p_store_id INT, OUT p_film_count INT)
+READS SQL DATA
+BEGIN
+     SELECT inventory_id
+     FROM inventory
+     WHERE film_id = p_film_id
+     AND store_id = p_store_id
+     AND inventory_in_stock(inventory_id);
+
+     SELECT COUNT(*)
+     FROM inventory
+     WHERE film_id = p_film_id
+     AND store_id = p_store_id
+     AND inventory_in_stock(inventory_id)
+     INTO p_film_count;
+END $$
+
+DELIMITER ;
+
+DELIMITER $$
+
+CREATE PROCEDURE film_not_in_stock(IN p_film_id INT, IN p_store_id INT, OUT p_film_count INT)
+READS SQL DATA
+BEGIN
+     SELECT inventory_id
+     FROM inventory
+     WHERE film_id = p_film_id
+     AND store_id = p_store_id
+     AND NOT inventory_in_stock(inventory_id);
+
+     SELECT COUNT(*)
+     FROM inventory
+     WHERE film_id = p_film_id
+     AND store_id = p_store_id
+     AND NOT inventory_in_stock(inventory_id)
+     INTO p_film_count;
+END $$
+
+DELIMITER ;
+
+DELIMITER $$
+
+CREATE FUNCTION inventory_held_by_customer(p_inventory_id INT) RETURNS INT
+READS SQL DATA
+BEGIN
+  DECLARE v_customer_id INT;
+  DECLARE EXIT HANDLER FOR NOT FOUND RETURN NULL;
+
+  SELECT customer_id INTO v_customer_id
+  FROM rental
+  WHERE return_date IS NULL
+  AND inventory_id = p_inventory_id;
+
+  RETURN v_customer_id;
+END $$
+
+DELIMITER ;
+
+DELIMITER $$
+
+CREATE FUNCTION inventory_in_stock(p_inventory_id INT) RETURNS BOOLEAN
+READS SQL DATA
+BEGIN
+    DECLARE v_rentals INT;
+    DECLARE v_out     INT;
+
+    #AN ITEM IS IN-STOCK IF THERE ARE EITHER NO ROWS IN THE rental TABLE
+    #FOR THE ITEM OR ALL ROWS HAVE return_date POPULATED
+
+    SELECT COUNT(*) INTO v_rentals
+    FROM rental
+    WHERE inventory_id = p_inventory_id;
+
+    IF v_rentals = 0 THEN
+      RETURN TRUE;
+    END IF;
+
+    SELECT COUNT(rental_id) INTO v_out
+    FROM inventory LEFT JOIN rental USING(inventory_id)
+    WHERE inventory.inventory_id = p_inventory_id
+    AND rental.return_date IS NULL;
+
+    IF v_out > 0 THEN
+      RETURN FALSE;
+    ELSE
+      RETURN TRUE;
+    END IF;
+END $$
+
+DELIMITER ;
+
+SET SQL_MODE=@OLD_SQL_MODE;
+SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;
+
+

--- a/go/testdata/sakila.mysql-small-query.log
+++ b/go/testdata/sakila.mysql-small-query.log
@@ -1,5 +1,5 @@
 
---skip
+--usage_count 123
 select * from actor where first_name = 'Scarlett';
 
 select * from actor where last_name like 'Johansson';

--- a/go/testdata/sakila.mysql-small-query.log
+++ b/go/testdata/sakila.mysql-small-query.log
@@ -1,0 +1,376 @@
+
+select * from actor where first_name = 'Scarlett';
+
+select * from actor where last_name like 'Johansson';
+
+select count(distinct last_name) from actor;
+
+select last_name from actor group by last_name having count(*) = 1;
+
+select last_name from actor group by last_name having count(*) > 1;
+
+select film.film_id, film.title, store.store_id, inventory.inventory_id
+from inventory join store on inventory.store_id = store.store_id join film on inventory.film_id = film.film_id
+where film.title = 'Academy Dinosaur' and store.store_id = 1;
+
+select inventory.inventory_id
+from inventory join store on inventory.store_id = store.store_id
+     join film on inventory.film_id = film.film_id
+     join rental on inventory.inventory_id = rental.inventory_id
+where film.title = 'Academy Dinosaur'
+      and store.store_id = 1
+      and not exists (select * from rental
+                      where rental.inventory_id = inventory.inventory_id
+                      and rental.return_date is null);
+
+insert into rental (rental_date, inventory_id, customer_id, staff_id)
+values (NOW(), 1, 1, 1);
+
+select rental_duration from film where film_id = 1;
+
+select rental_id from rental order by rental_id desc limit 1;
+
+select rental_date,
+       rental_date + interval
+                   (select rental_duration from film where film_id = 1) day
+                   as due_date
+from rental
+where rental_id = (select rental_id from rental order by rental_id desc limit 1);
+
+select avg(length) from film;
+
+SELECT first_name, last_name
+FROM actor;
+
+SELECT UPPER(CONCAT(first_name, ' ', last_name)) AS 'Actor Name'
+FROM actor;
+
+SELECT first_name, last_name, actor_id
+FROM actor
+WHERE first_name = "Joe";
+
+SELECT * FROM actor
+WHERE last_name LIKE '%GEN%';
+
+SELECT last_name, first_name
+FROM actor
+WHERE last_name LIKE '%LI%'
+ORDER BY last_name, first_name;
+
+SELECT country_id, country
+FROM country
+WHERE country IN ('Afghanistan', 'Bangladesh', 'China');
+
+
+SELECT last_name, COUNT(*) AS 'count'
+FROM actor
+GROUP BY last_name;
+
+SELECT last_name, COUNT(*) AS 'count'
+FROM actor
+GROUP BY last_name
+HAVING COUNT(*) > 1;
+
+UPDATE actor
+SET first_name ='HARPO'
+WHERE (first_name ='GROUCHO' AND last_name = 'WILLIAMS');
+
+UPDATE actor
+SET first_name =
+CASE WHEN first_name = 'HARPO'
+THEN 'GROUCHO'
+ELSE 'MUCHO GROUCHO'
+END
+WHERE actor_id = 172;
+
+SELECT s.first_name, s.last_name, a.address
+FROM staff s
+INNER JOIN address a
+ON (s.address_id = a.address_id);
+
+SELECT s.first_name, s.last_name, SUM(p.amount)
+FROM staff s
+INNER JOIN payment p
+ON (s.staff_id = p.staff_id)
+WHERE MONTH(p.payment_date) = 08 AND YEAR(p.payment_date) = 2005
+GROUP BY s.staff_id;
+
+SELECT f.title, COUNT(a.actor_id) AS 'Number of Actors'
+FROM film f
+INNER JOIN film_actor a
+ON (f.film_id = a.film_id)
+GROUP BY f.title
+ORDER BY 'Number of Actors' DESC;
+
+SELECT title, COUNT(inventory_id) AS 'Number of copies'
+FROM film
+INNER JOIN inventory
+ON (film.film_id = inventory.film_id)
+WHERE title = 'Hunchback Impossible'
+GROUP BY title;
+
+SELECT c.last_name, c.first_name, SUM(p.amount) AS 'Total Amount Paid'
+FROM customer c
+INNER JOIN payment p
+ON (c.customer_id = p.customer_id)
+GROUP BY c.last_name
+ORDER BY c.last_name;
+
+SELECT title
+FROM film
+WHERE title LIKE 'K%'
+OR title LIKE 'Q%'
+AND language_id IN
+(SELECT language_id
+FROM language
+WHERE name = 'English');
+
+SELECT first_name, last_name
+FROM actor
+WHERE actor_id IN
+(SELECT actor_id
+FROM film_actor
+WHERE film_id IN
+(SELECT film_id
+FROM film
+WHERE title = 'Alone Trip'));
+
+SELECT c.first_name, c.last_name, c.email
+FROM customer c
+JOIN address a ON (c.address_id = a.address_id)
+JOIN city ci ON (a.city_id = ci.city_id)
+JOIN country ctr ON (ci.country_id = ctr.country_id)
+WHERE ctr.country = 'canada';
+
+SELECT title, c.name
+FROM film f
+JOIN film_category fc
+ON (f.film_id = fc.film_id)
+JOIN category c
+ON (c.category_id = fc.category_id)
+WHERE name = 'family';
+
+SELECT s.store_id, SUM(amount) AS 'Revenue'
+FROM payment p
+JOIN rental r
+ON (p.rental_id = r.rental_id)
+JOIN inventory i
+ON (i.inventory_id = r.inventory_id)
+JOIN store s
+ON (s.store_id = i.store_id)
+GROUP BY s.store_id;
+
+SELECT store_id, city, country
+FROM store s
+JOIN address a
+ON (s.address_id = a.address_id)
+JOIN city cit
+ON (cit.city_id = a.city_id)
+JOIN country ctr
+ON(cit.country_id = ctr.country_id);
+
+SELECT SUM(amount) AS 'Total Sales', c.name AS 'Genre'
+FROM payment p
+JOIN rental r
+ON (p.rental_id = r.rental_id)
+JOIN inventory i
+ON (r.inventory_id = i.inventory_id)
+JOIN film_category fc
+ON (i.film_id = fc.film_id)
+JOIN category c
+ON (fc.category_id = c.category_id)
+GROUP BY c.name
+ORDER BY SUM(amount) DESC;
+
+SELECT SUM(amount) AS 'Total Sales', c.name AS 'Genre'
+FROM payment p
+JOIN rental r
+ON (p.rental_id = r.rental_id)
+JOIN inventory i
+ON (r.inventory_id = i.inventory_id)
+JOIN film_category fc
+ON (i.film_id = fc.film_id)
+JOIN category c
+ON (fc.category_id = c.category_id)
+GROUP BY c.name
+ORDER BY SUM(amount) DESC
+LIMIT 5;
+
+SELECT *
+FROM top_five_genres;
+
+# Following queries simulate lots of queries joining with lookup-style tables
+
+SELECT
+    /*vt+ VT_USAGE_COUNT=1000 */
+    f.title AS film_title,
+    CONCAT(a.first_name, ' ', a.last_name) AS actor_name
+FROM
+    film f
+INNER JOIN
+    film_actor fa ON f.film_id = fa.film_id
+INNER JOIN
+    actor a ON fa.actor_id = a.actor_id
+ORDER BY
+    film_title, actor_name;
+
+SELECT
+    /*vt+ VT_USAGE_COUNT=500 */
+    f.title AS film_title,
+    c.name AS category_name
+FROM
+    film f
+INNER JOIN
+    film_category fc ON f.film_id = fc.film_id
+INNER JOIN
+    category c ON fc.category_id = c.category_id
+ORDER BY
+    category_name, film_title;
+
+SELECT
+    /*vt+ VT_USAGE_COUNT=500 */
+    CONCAT(c.first_name, ' ', c.last_name) AS customer_name,
+    ci.city AS city_name,
+    co.country AS country_name
+FROM
+    customer c
+INNER JOIN
+    address a ON c.address_id = a.address_id
+INNER JOIN
+    city ci ON a.city_id = ci.city_id
+INNER JOIN
+    country co ON ci.country_id = co.country_id
+ORDER BY
+    country_name, city_name, customer_name;
+
+SELECT
+    /*vt+ VT_USAGE_COUNT=3413 */
+    i.inventory_id,
+    f.title AS film_title,
+    l.name AS language_name
+FROM
+    inventory i
+INNER JOIN
+    film f ON i.film_id = f.film_id
+INNER JOIN
+    language l ON f.language_id = l.language_id
+ORDER BY
+    language_name, film_title;
+
+SELECT
+    /*vt+ VT_USAGE_COUNT=7342 */
+    s.store_id,
+    CONCAT(st.first_name, ' ', st.last_name) AS staff_name,
+    ci.city AS store_city,
+    co.country AS store_country
+FROM
+    store s
+INNER JOIN
+    staff st ON s.manager_staff_id = st.staff_id
+INNER JOIN
+    address a ON s.address_id = a.address_id
+INNER JOIN
+    city ci ON a.city_id = ci.city_id
+INNER JOIN
+    country co ON ci.country_id = co.country_id
+WHERE
+    st.active = TRUE
+ORDER BY
+    store_country, store_city, staff_name;
+
+SELECT
+    /*vt+ VT_USAGE_COUNT=1900 */
+    l.name AS language_name,
+    COUNT(f.film_id) AS film_count
+FROM
+    film f
+INNER JOIN
+    language l ON f.language_id = l.language_id
+GROUP BY
+    l.language_id, l.name
+ORDER BY
+    film_count DESC, language_name;
+
+INSERT INTO film (title, description, release_year, language_id, rental_duration, rental_rate, length, replacement_cost, rating)
+VALUES ('The Grand Adventure', 'A thrilling journey through unknown lands.', 2024, 1, 5, 3.99, 120, 14.99, 'PG'); /*vt+ VT_USAGE_COUNT=4321 */
+
+DELETE /*vt+ VT_USAGE_COUNT=8723 */ FROM customer
+WHERE customer_id = 101;
+
+UPDATE /*vt+ VT_USAGE_COUNT=2841 */ rental
+SET return_date = NOW()
+WHERE rental_id = 204 AND return_date IS NULL;
+
+INSERT /*vt+ VT_USAGE_COUNT=6402 */ INTO inventory (film_id, store_id, last_update)
+VALUES (5, 1, NOW());
+
+DELETE /*vt+ VT_USAGE_COUNT=5298 */ FROM payment
+WHERE payment_id = 305;
+
+UPDATE /*vt+ VT_USAGE_COUNT=3789 */ staff
+SET active = FALSE
+WHERE staff_id = 2;
+
+INSERT /*vt+ VT_USAGE_COUNT=9147 */ INTO rental (rental_date, inventory_id, customer_id, staff_id)
+VALUES (NOW(), 101, 305, 1);
+
+DELETE /*vt+ VT_USAGE_COUNT=1 */ FROM address
+WHERE address_id = 200;
+
+UPDATE /*vt+ VT_USAGE_COUNT=7083 */ store
+SET manager_staff_id = 3
+WHERE store_id = 2;
+
+INSERT /*vt+ VT_USAGE_COUNT=3456 */ INTO film_actor (actor_id, film_id, last_update)
+VALUES (10, 15, NOW());
+
+INSERT /*vt+ VT_USAGE_COUNT=12 */ INTO actor (first_name, last_name, last_update)
+VALUES ('John', 'Doe', NOW());
+
+DELETE /*vt+ VT_USAGE_COUNT=8 */ FROM actor
+WHERE actor_id = 15;
+
+UPDATE /*vt+ VT_USAGE_COUNT=25 */ actor
+SET last_name = 'Smith'
+WHERE actor_id = 22;
+
+INSERT /*vt+ VT_USAGE_COUNT=18 */ INTO category (name, last_update)
+VALUES ('Adventure', NOW());
+
+DELETE /*vt+ VT_USAGE_COUNT=10 */ FROM category
+WHERE category_id = 4;
+
+UPDATE /*vt+ VT_USAGE_COUNT=30 */ category
+SET name = 'Drama'
+WHERE category_id = 7;
+
+INSERT /*vt+ VT_USAGE_COUNT=5 */ INTO language (name, last_update)
+VALUES ('Mandarin', NOW());
+
+DELETE /*vt+ VT_USAGE_COUNT=1 */ FROM language
+WHERE language_id = 5;
+
+UPDATE /*vt+ VT_USAGE_COUNT=3 */ language
+SET name = 'French'
+WHERE language_id = 2;
+
+INSERT /*vt+ VT_USAGE_COUNT=22 */ INTO city (city, country_id, last_update)
+VALUES ('Amsterdam', 1, NOW());
+
+DELETE /*vt+ VT_USAGE_COUNT=16 */ FROM city
+WHERE city_id = 101;
+
+UPDATE /*vt+ VT_USAGE_COUNT=7 */ city
+SET city = 'New York'
+WHERE city_id = 50;
+
+INSERT /*vt+ VT_USAGE_COUNT=3 */ INTO country (country, last_update)
+VALUES ('Netherlands', NOW());
+
+DELETE /*vt+ VT_USAGE_COUNT=9 */ FROM country
+WHERE country_id = 25;
+
+UPDATE /*vt+ VT_USAGE_COUNT=35 */ country
+SET country = 'Germany'
+WHERE country_id = 12;
+

--- a/go/testdata/sakila.mysql-small-query.log
+++ b/go/testdata/sakila.mysql-small-query.log
@@ -1,4 +1,5 @@
 
+--skip
 select * from actor where first_name = 'Scarlett';
 
 select * from actor where last_name like 'Johansson';
@@ -202,7 +203,6 @@ FROM top_five_genres;
 # Following queries simulate lots of queries joining with lookup-style tables
 
 SELECT
-    /*vt+ VT_USAGE_COUNT=1000 */
     f.title AS film_title,
     CONCAT(a.first_name, ' ', a.last_name) AS actor_name
 FROM
@@ -215,7 +215,6 @@ ORDER BY
     film_title, actor_name;
 
 SELECT
-    /*vt+ VT_USAGE_COUNT=500 */
     f.title AS film_title,
     c.name AS category_name
 FROM
@@ -228,7 +227,6 @@ ORDER BY
     category_name, film_title;
 
 SELECT
-    /*vt+ VT_USAGE_COUNT=500 */
     CONCAT(c.first_name, ' ', c.last_name) AS customer_name,
     ci.city AS city_name,
     co.country AS country_name
@@ -244,7 +242,6 @@ ORDER BY
     country_name, city_name, customer_name;
 
 SELECT
-    /*vt+ VT_USAGE_COUNT=3413 */
     i.inventory_id,
     f.title AS film_title,
     l.name AS language_name
@@ -258,7 +255,6 @@ ORDER BY
     language_name, film_title;
 
 SELECT
-    /*vt+ VT_USAGE_COUNT=7342 */
     s.store_id,
     CONCAT(st.first_name, ' ', st.last_name) AS staff_name,
     ci.city AS store_city,
@@ -279,7 +275,6 @@ ORDER BY
     store_country, store_city, staff_name;
 
 SELECT
-    /*vt+ VT_USAGE_COUNT=1900 */
     l.name AS language_name,
     COUNT(f.film_id) AS film_count
 FROM
@@ -292,85 +287,85 @@ ORDER BY
     film_count DESC, language_name;
 
 INSERT INTO film (title, description, release_year, language_id, rental_duration, rental_rate, length, replacement_cost, rating)
-VALUES ('The Grand Adventure', 'A thrilling journey through unknown lands.', 2024, 1, 5, 3.99, 120, 14.99, 'PG'); /*vt+ VT_USAGE_COUNT=4321 */
+VALUES ('The Grand Adventure', 'A thrilling journey through unknown lands.', 2024, 1, 5, 3.99, 120, 14.99, 'PG');
 
-DELETE /*vt+ VT_USAGE_COUNT=8723 */ FROM customer
+DELETE FROM customer
 WHERE customer_id = 101;
 
-UPDATE /*vt+ VT_USAGE_COUNT=2841 */ rental
+UPDATE rental
 SET return_date = NOW()
 WHERE rental_id = 204 AND return_date IS NULL;
 
-INSERT /*vt+ VT_USAGE_COUNT=6402 */ INTO inventory (film_id, store_id, last_update)
+INSERT INTO inventory (film_id, store_id, last_update)
 VALUES (5, 1, NOW());
 
-DELETE /*vt+ VT_USAGE_COUNT=5298 */ FROM payment
+DELETE FROM payment
 WHERE payment_id = 305;
 
-UPDATE /*vt+ VT_USAGE_COUNT=3789 */ staff
+UPDATE staff
 SET active = FALSE
 WHERE staff_id = 2;
 
-INSERT /*vt+ VT_USAGE_COUNT=9147 */ INTO rental (rental_date, inventory_id, customer_id, staff_id)
+INSERT INTO rental (rental_date, inventory_id, customer_id, staff_id)
 VALUES (NOW(), 101, 305, 1);
 
-DELETE /*vt+ VT_USAGE_COUNT=1 */ FROM address
+DELETE FROM address
 WHERE address_id = 200;
 
-UPDATE /*vt+ VT_USAGE_COUNT=7083 */ store
+UPDATE store
 SET manager_staff_id = 3
 WHERE store_id = 2;
 
-INSERT /*vt+ VT_USAGE_COUNT=3456 */ INTO film_actor (actor_id, film_id, last_update)
+INSERT INTO film_actor (actor_id, film_id, last_update)
 VALUES (10, 15, NOW());
 
-INSERT /*vt+ VT_USAGE_COUNT=12 */ INTO actor (first_name, last_name, last_update)
+INSERT INTO actor (first_name, last_name, last_update)
 VALUES ('John', 'Doe', NOW());
 
-DELETE /*vt+ VT_USAGE_COUNT=8 */ FROM actor
+DELETE FROM actor
 WHERE actor_id = 15;
 
-UPDATE /*vt+ VT_USAGE_COUNT=25 */ actor
+UPDATE actor
 SET last_name = 'Smith'
 WHERE actor_id = 22;
 
-INSERT /*vt+ VT_USAGE_COUNT=18 */ INTO category (name, last_update)
+INSERT INTO category (name, last_update)
 VALUES ('Adventure', NOW());
 
-DELETE /*vt+ VT_USAGE_COUNT=10 */ FROM category
+DELETE FROM category
 WHERE category_id = 4;
 
-UPDATE /*vt+ VT_USAGE_COUNT=30 */ category
+UPDATE category
 SET name = 'Drama'
 WHERE category_id = 7;
 
-INSERT /*vt+ VT_USAGE_COUNT=5 */ INTO language (name, last_update)
+INSERT INTO language (name, last_update)
 VALUES ('Mandarin', NOW());
 
-DELETE /*vt+ VT_USAGE_COUNT=1 */ FROM language
+DELETE FROM language
 WHERE language_id = 5;
 
-UPDATE /*vt+ VT_USAGE_COUNT=3 */ language
+UPDATE language
 SET name = 'French'
 WHERE language_id = 2;
 
-INSERT /*vt+ VT_USAGE_COUNT=22 */ INTO city (city, country_id, last_update)
+INSERT INTO city (city, country_id, last_update)
 VALUES ('Amsterdam', 1, NOW());
 
-DELETE /*vt+ VT_USAGE_COUNT=16 */ FROM city
+DELETE FROM city
 WHERE city_id = 101;
 
-UPDATE /*vt+ VT_USAGE_COUNT=7 */ city
+UPDATE city
 SET city = 'New York'
 WHERE city_id = 50;
 
-INSERT /*vt+ VT_USAGE_COUNT=3 */ INTO country (country, last_update)
+INSERT INTO country (country, last_update)
 VALUES ('Netherlands', NOW());
 
-DELETE /*vt+ VT_USAGE_COUNT=9 */ FROM country
+DELETE FROM country
 WHERE country_id = 25;
 
-UPDATE /*vt+ VT_USAGE_COUNT=35 */ country
+UPDATE country
 SET country = 'Germany'
 WHERE country_id = 12;
 

--- a/t/directives.test
+++ b/t/directives.test
@@ -49,3 +49,8 @@ select 2;
 # Since reference tables are copied to all shards, this query will be executed on all shards.
 --reference
 insert into reference_table values (1, 2, 3);
+
+# --usage_count
+# This directive is used to indicate how many times the following query has been deemed to be executed.
+--usage_count 10
+select * from some_table;


### PR DESCRIPTION

### Enhanced summarize

Added a new flag `schema-info-path` to specify the output of the `vt schema` command. It updates the table summary with the number of rows per table and adds it to the summary output.

### new schema sub-command

Added a `vt schema` command that takes connection information to a running MySQL instance and gets (for now) the number of rows per table from the `information_schema`.  It outputs a schema info json file for ingestion by `summarize`.

We will enhance this to get additional info like PKs, indexes, FKs, Column info, Selectivity (in the future) etc. 

### Miscellaneous

* Fixed error messages for keys command
* Adds a `usage_count` directive which will allow users to specify the number of times a query was called. This is a shortcut to having to specify the same query / query pattern multiple times to simulate real world usage
* Added `sakila` related test files

### Todos

* Add test that launches a cluster to test the schema command