### PR TITLE
dbinfo: add info for primary keys, indexes, foreign keys

### DIFF
--- a/go/dbinfo/dbinfo.go
+++ b/go/dbinfo/dbinfo.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"sort"
 
 	"vitess.io/vitess/go/mysql"
 )
@@ -53,19 +54,110 @@ type TableColumn struct {
 	Extra      string `json:"extra,omitempty"`
 }
 
+type PrimaryKey struct {
+	Columns []string `json:"columns"`
+}
+
+type Index struct {
+	Name      string
+	Columns   []string `json:"columns"`
+	NonUnique bool     `json:"nonUnique,omitempty"`
+}
+
+type ForeignKey struct {
+	ColumnName           string `json:"columnName"`
+	ConstraintName       string `json:"constraintName"`
+	ReferencedTableName  string `json:"referencedTableName"`
+	ReferencedColumnName string `json:"referencedColumnName"`
+}
+
 type TableInfo struct {
-	Name    string         `json:"name"`
-	Rows    int            `json:"rows"`
-	Columns []*TableColumn `json:"columns"`
+	Name        string         `json:"name"`
+	Rows        int            `json:"rows"`
+	Columns     []*TableColumn `json:"columns"`
+	PrimaryKey  *PrimaryKey    `json:"primaryKey,omitempty"`
+	Indexes     []*Index       `json:"indexes,omitempty"`
+	ForeignKeys []*ForeignKey  `json:"foreignKeys,omitempty"`
 }
 
 type Info struct {
 	FileType        string            `json:"fileType"`
 	Tables          []*TableInfo      `json:"tables"`
 	GlobalVariables map[string]string `json:"globalVariables"`
-	PrimaryKeys     PrimaryKeys       `json:"primaryKeys"`
-	Indexes         Indexes           `json:"indexes"`
-	ForeignKeys     ForeignKeys       `json:"foreignKeys"`
+}
+
+func getTableSizes(dbh *DBHelper, tableMap map[string]*TableInfo) error {
+	ts, err := dbh.getTableSizes()
+	if err != nil {
+		return err
+	}
+
+	for tableName, tableRows := range ts {
+		ti, ok := tableMap[tableName]
+		if !ok {
+			ti = &TableInfo{
+				Name: tableName,
+			}
+			tableMap[tableName] = ti
+		}
+		ti.Rows = tableRows
+	}
+	return nil
+}
+
+func getPrimaryKeys(dbh *DBHelper, tableMap map[string]*TableInfo) error {
+	pks, err := dbh.getPrimaryKeys()
+	if err != nil {
+		return err
+	}
+
+	for tableName, pk := range pks {
+		ti, ok := tableMap[tableName]
+		if !ok {
+			ti = &TableInfo{}
+			tableMap[tableName] = ti
+		}
+		ti.PrimaryKey = &PrimaryKey{
+			Columns: pk.columns,
+		}
+	}
+	return nil
+}
+
+func getIndexes(dbh *DBHelper, tableMap map[string]*TableInfo) error {
+	idxs, err := dbh.getIndexes()
+	if err != nil {
+		return err
+	}
+
+	for tableName, tidx := range idxs {
+		ti, ok := tableMap[tableName]
+		if !ok {
+			ti = &TableInfo{}
+			tableMap[tableName] = ti
+		}
+		for _, idx := range tidx.indexes {
+			ti.Indexes = append(ti.Indexes, idx)
+		}
+	}
+	return nil
+}
+
+func getForeignKeys(dbh *DBHelper, tableMap map[string]*TableInfo) error {
+	fks, err := dbh.getForeignKeys()
+	if err != nil {
+		return err
+	}
+
+	for fkName, fk := range fks {
+		ti, ok := tableMap[fkName]
+		if !ok {
+			ti = &TableInfo{}
+			tableMap[fkName] = ti
+		}
+		ti.ForeignKeys = fk
+	}
+	return nil
 }
 
 func Get(cfg Config) (*Info, error) {
@@ -77,69 +169,43 @@ func Get(cfg Config) (*Info, error) {
 		DbName: cfg.VTParams.DbName,
 	}
 
-	dbh := NewDBHelper(vtParams)
-	ts, err := dbh.getTableSizes()
-	if err != nil {
-		return nil, err
-	}
-
 	var tableInfo []*TableInfo
 	tableMap := make(map[string]*TableInfo)
 
-	for tableName, tableRows := range ts {
-		tableMap[tableName] = &TableInfo{
-			Name: tableName,
-			Rows: tableRows,
-		}
-	}
-
-	tc, err := dbh.getColumnInfo()
-	if err != nil {
-		return nil, err
-	}
-
-	for tableName, columns := range tc {
-		ti, ok := tableMap[tableName]
-		if !ok {
-			ti = &TableInfo{
-				Name: tableName,
-			}
-			tableMap[tableName] = ti
-		}
-		ti.Columns = columns
-	}
-
-	for tableName := range tableMap {
-		tableInfo = append(tableInfo, tableMap[tableName])
-	}
+	dbh := NewDBHelper(vtParams)
 
 	globalVariables, err := dbh.getGlobalVariables()
 	if err != nil {
 		return nil, err
 	}
 
-	primaryKeys, err := dbh.getPrimaryKeys()
-	if err != nil {
+	if err := getTableSizes(dbh, tableMap); err != nil {
 		return nil, err
 	}
 
-	indexes, err := dbh.getIndexes()
-	if err != nil {
+	if err := getPrimaryKeys(dbh, tableMap); err != nil {
 		return nil, err
 	}
 
-	foreignKeys, err := dbh.getForeignKeys()
-	if err != nil {
+	if err := getIndexes(dbh, tableMap); err != nil {
 		return nil, err
 	}
+
+	if err := getForeignKeys(dbh, tableMap); err != nil {
+		return nil, err
+	}
+
+	for tableName := range tableMap {
+		tableInfo = append(tableInfo, tableMap[tableName])
+	}
+	sort.Slice(tableInfo, func(i, j int) bool {
+		return tableInfo[i].Name < tableInfo[j].Name
+	})
 
 	dbInfo := &Info{
 		FileType:        "dbinfo",
 		Tables:          tableInfo,
 		GlobalVariables: globalVariables,
-		PrimaryKeys:     primaryKeys,
-		Indexes:         indexes,
-		ForeignKeys:     foreignKeys,
 	}
 	return dbInfo, nil
 }

--- a/go/dbinfo/dbinfo.go
+++ b/go/dbinfo/dbinfo.go
@@ -63,6 +63,9 @@ type Info struct {
 	FileType        string            `json:"fileType"`
 	Tables          []*TableInfo      `json:"tables"`
 	GlobalVariables map[string]string `json:"globalVariables"`
+	PrimaryKeys     PrimaryKeys       `json:"primaryKeys"`
+	Indexes         Indexes           `json:"indexes"`
+	ForeignKeys     ForeignKeys       `json:"foreignKeys"`
 }
 
 func Get(cfg Config) (*Info, error) {
@@ -115,10 +118,28 @@ func Get(cfg Config) (*Info, error) {
 		return nil, err
 	}
 
+	primaryKeys, err := dbh.getPrimaryKeys()
+	if err != nil {
+		return nil, err
+	}
+
+	indexes, err := dbh.getIndexes()
+	if err != nil {
+		return nil, err
+	}
+
+	foreignKeys, err := dbh.getForeignKeys()
+	if err != nil {
+		return nil, err
+	}
+
 	dbInfo := &Info{
 		FileType:        "dbinfo",
 		Tables:          tableInfo,
 		GlobalVariables: globalVariables,
+		PrimaryKeys:     primaryKeys,
+		Indexes:         indexes,
+		ForeignKeys:     foreignKeys,
 	}
 	return dbInfo, nil
 }

--- a/go/dbinfo/dbinfo_test.go
+++ b/go/dbinfo/dbinfo_test.go
@@ -54,10 +54,11 @@ func TestDBInfoLoad(t *testing.T) {
 
 	t.Run("validateGlobalVariables", func(t *testing.T) {
 		require.NotEmpty(t, si.GlobalVariables)
-		require.Len(t, si.GlobalVariables, 3)
+		require.Len(t, si.GlobalVariables, 4)
 		expected := map[string]string{
 			"binlog_format":    "ROW",
 			"binlog_row_image": "FULL",
+			"gtid_mode":        "OFF",
 			"log_bin":          "ON",
 		}
 		require.EqualValues(t, expected, si.GlobalVariables)
@@ -159,26 +160,26 @@ func TestDBInfoGet(t *testing.T) {
 		for tableName, Columns := range want {
 			pk, ok := pks[tableName]
 			require.True(t, ok)
-			require.Equal(t, Columns, pk.Columns)
+			require.Equal(t, Columns, pk.columns)
 		}
 	})
 
 	t.Run("indexes", func(t *testing.T) {
 		idxs, err := dbh.getIndexes()
 		require.NoError(t, err)
-		require.Equal(t, 16, idxs.len())
+		require.Len(t, idxs, 16)
 		idx, ok := idxs["film_actor"]
 		require.True(t, ok)
-		require.Len(t, idx.Indexes, 2)
-		require.Equal(t, "idx_fk_film_id", idx.Indexes["idx_fk_film_id"].IndexName)
-		require.Equal(t, []string{"film_id"}, idx.Indexes["idx_fk_film_id"].Columns)
+		require.Len(t, idx.indexes, 2)
+		require.Equal(t, "idx_fk_film_id", idx.indexes["idx_fk_film_id"].Name)
+		require.Equal(t, []string{"film_id"}, idx.indexes["idx_fk_film_id"].Columns)
 		idx, ok = idxs["rental"]
 		require.True(t, ok)
-		require.Len(t, idx.Indexes, 5)
-		require.Equal(t, "rental_date", idx.Indexes["rental_date"].IndexName)
-		require.Equal(t, []string{"rental_date", "inventory_id", "customer_id"}, idx.Indexes["rental_date"].Columns)
-		require.Equal(t, "PRIMARY", idx.Indexes["PRIMARY_KEY"].IndexName)
-		require.Equal(t, []string{"rental_id"}, idx.Indexes["PRIMARY_KEY"].Columns)
+		require.Len(t, idx.indexes, 5)
+		require.Equal(t, "rental_date", idx.indexes["rental_date"].Name)
+		require.Equal(t, []string{"rental_date", "inventory_id", "customer_id"}, idx.indexes["rental_date"].Columns)
+		require.Equal(t, "PRIMARY", idx.indexes["PRIMARY_KEY"].Name)
+		require.Equal(t, []string{"rental_id"}, idx.indexes["PRIMARY_KEY"].Columns)
 	})
 
 	t.Run("foreign keys", func(t *testing.T) {
@@ -188,7 +189,6 @@ func TestDBInfoGet(t *testing.T) {
 		fk, ok := fks["city"]
 		require.True(t, ok)
 		require.Len(t, fk, 1)
-		require.Equal(t, "city", fk[0].TableName)
 		require.Equal(t, "country_id", fk[0].ColumnName)
 		require.Equal(t, "fk_city_country", fk[0].ConstraintName)
 		require.Equal(t, "country", fk[0].ReferencedTableName)
@@ -197,12 +197,10 @@ func TestDBInfoGet(t *testing.T) {
 		fk, ok = fks["store"]
 		require.True(t, ok)
 		require.Len(t, fk, 2)
-		require.Equal(t, "store", fk[0].TableName)
 		require.Equal(t, "address_id", fk[0].ColumnName)
 		require.Equal(t, "fk_store_address", fk[0].ConstraintName)
 		require.Equal(t, "address", fk[0].ReferencedTableName)
 		require.Equal(t, "address_id", fk[0].ReferencedColumnName)
-		require.Equal(t, "store", fk[1].TableName)
 		require.Equal(t, "manager_staff_id", fk[1].ColumnName)
 		require.Equal(t, "fk_store_staff", fk[1].ConstraintName)
 		require.Equal(t, "staff", fk[1].ReferencedTableName)

--- a/go/dbinfo/dbinfo_test.go
+++ b/go/dbinfo/dbinfo_test.go
@@ -144,4 +144,68 @@ func TestDBInfoGet(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, gv)
 	})
+
+	t.Run("primary keys", func(t *testing.T) {
+		pks, err := dbh.getPrimaryKeys()
+		require.NoError(t, err)
+		require.Len(t, pks, 16)
+		want := map[string][]string{
+			"actor":         {"actor_id"},
+			"film":          {"film_id"},
+			"language":      {"language_id"},
+			"film_category": {"film_id", "category_id"},
+			"film_actor":    {"actor_id", "film_id"},
+		}
+		for tableName, columns := range want {
+			pk, ok := pks[tableName]
+			require.True(t, ok)
+			require.Equal(t, columns, pk.columns)
+		}
+	})
+
+	t.Run("indexes", func(t *testing.T) {
+		idxs, err := dbh.getIndexes()
+		require.NoError(t, err)
+		require.Equal(t, 16, idxs.len())
+		idx, ok := idxs["film_actor"]
+		require.True(t, ok)
+		require.Len(t, idx.indexes, 2)
+		require.Equal(t, "idx_fk_film_id", idx.indexes["idx_fk_film_id"].indexName)
+		require.Equal(t, []string{"film_id"}, idx.indexes["idx_fk_film_id"].columns)
+		idx, ok = idxs["rental"]
+		require.True(t, ok)
+		require.Len(t, idx.indexes, 5)
+		require.Equal(t, "rental_date", idx.indexes["rental_date"].indexName)
+		require.Equal(t, []string{"rental_date", "inventory_id", "customer_id"}, idx.indexes["rental_date"].columns)
+		require.Equal(t, "PRIMARY", idx.indexes["PRIMARY_KEY"].indexName)
+		require.Equal(t, []string{"rental_id"}, idx.indexes["PRIMARY_KEY"].columns)
+	})
+
+	t.Run("foreign keys", func(t *testing.T) {
+		fks, err := dbh.getForeignKeys()
+		require.NoError(t, err)
+		require.Len(t, fks, 11)
+		fk, ok := fks["city"]
+		require.True(t, ok)
+		require.Len(t, fk, 1)
+		require.Equal(t, "city", fk[0].tableName)
+		require.Equal(t, "country_id", fk[0].columnName)
+		require.Equal(t, "fk_city_country", fk[0].constraintName)
+		require.Equal(t, "country", fk[0].referencedTableName)
+		require.Equal(t, "country_id", fk[0].referencedColumnName)
+
+		fk, ok = fks["store"]
+		require.True(t, ok)
+		require.Len(t, fk, 2)
+		require.Equal(t, "store", fk[0].tableName)
+		require.Equal(t, "address_id", fk[0].columnName)
+		require.Equal(t, "fk_store_address", fk[0].constraintName)
+		require.Equal(t, "address", fk[0].referencedTableName)
+		require.Equal(t, "address_id", fk[0].referencedColumnName)
+		require.Equal(t, "store", fk[1].tableName)
+		require.Equal(t, "manager_staff_id", fk[1].columnName)
+		require.Equal(t, "fk_store_staff", fk[1].constraintName)
+		require.Equal(t, "staff", fk[1].referencedTableName)
+		require.Equal(t, "staff_id", fk[1].referencedColumnName)
+	})
 }

--- a/go/dbinfo/dbinfo_test.go
+++ b/go/dbinfo/dbinfo_test.go
@@ -156,10 +156,10 @@ func TestDBInfoGet(t *testing.T) {
 			"film_category": {"film_id", "category_id"},
 			"film_actor":    {"actor_id", "film_id"},
 		}
-		for tableName, columns := range want {
+		for tableName, Columns := range want {
 			pk, ok := pks[tableName]
 			require.True(t, ok)
-			require.Equal(t, columns, pk.columns)
+			require.Equal(t, Columns, pk.Columns)
 		}
 	})
 
@@ -169,16 +169,16 @@ func TestDBInfoGet(t *testing.T) {
 		require.Equal(t, 16, idxs.len())
 		idx, ok := idxs["film_actor"]
 		require.True(t, ok)
-		require.Len(t, idx.indexes, 2)
-		require.Equal(t, "idx_fk_film_id", idx.indexes["idx_fk_film_id"].indexName)
-		require.Equal(t, []string{"film_id"}, idx.indexes["idx_fk_film_id"].columns)
+		require.Len(t, idx.Indexes, 2)
+		require.Equal(t, "idx_fk_film_id", idx.Indexes["idx_fk_film_id"].IndexName)
+		require.Equal(t, []string{"film_id"}, idx.Indexes["idx_fk_film_id"].Columns)
 		idx, ok = idxs["rental"]
 		require.True(t, ok)
-		require.Len(t, idx.indexes, 5)
-		require.Equal(t, "rental_date", idx.indexes["rental_date"].indexName)
-		require.Equal(t, []string{"rental_date", "inventory_id", "customer_id"}, idx.indexes["rental_date"].columns)
-		require.Equal(t, "PRIMARY", idx.indexes["PRIMARY_KEY"].indexName)
-		require.Equal(t, []string{"rental_id"}, idx.indexes["PRIMARY_KEY"].columns)
+		require.Len(t, idx.Indexes, 5)
+		require.Equal(t, "rental_date", idx.Indexes["rental_date"].IndexName)
+		require.Equal(t, []string{"rental_date", "inventory_id", "customer_id"}, idx.Indexes["rental_date"].Columns)
+		require.Equal(t, "PRIMARY", idx.Indexes["PRIMARY_KEY"].IndexName)
+		require.Equal(t, []string{"rental_id"}, idx.Indexes["PRIMARY_KEY"].Columns)
 	})
 
 	t.Run("foreign keys", func(t *testing.T) {
@@ -188,24 +188,24 @@ func TestDBInfoGet(t *testing.T) {
 		fk, ok := fks["city"]
 		require.True(t, ok)
 		require.Len(t, fk, 1)
-		require.Equal(t, "city", fk[0].tableName)
-		require.Equal(t, "country_id", fk[0].columnName)
-		require.Equal(t, "fk_city_country", fk[0].constraintName)
-		require.Equal(t, "country", fk[0].referencedTableName)
-		require.Equal(t, "country_id", fk[0].referencedColumnName)
+		require.Equal(t, "city", fk[0].TableName)
+		require.Equal(t, "country_id", fk[0].ColumnName)
+		require.Equal(t, "fk_city_country", fk[0].ConstraintName)
+		require.Equal(t, "country", fk[0].ReferencedTableName)
+		require.Equal(t, "country_id", fk[0].ReferencedColumnName)
 
 		fk, ok = fks["store"]
 		require.True(t, ok)
 		require.Len(t, fk, 2)
-		require.Equal(t, "store", fk[0].tableName)
-		require.Equal(t, "address_id", fk[0].columnName)
-		require.Equal(t, "fk_store_address", fk[0].constraintName)
-		require.Equal(t, "address", fk[0].referencedTableName)
-		require.Equal(t, "address_id", fk[0].referencedColumnName)
-		require.Equal(t, "store", fk[1].tableName)
-		require.Equal(t, "manager_staff_id", fk[1].columnName)
-		require.Equal(t, "fk_store_staff", fk[1].constraintName)
-		require.Equal(t, "staff", fk[1].referencedTableName)
-		require.Equal(t, "staff_id", fk[1].referencedColumnName)
+		require.Equal(t, "store", fk[0].TableName)
+		require.Equal(t, "address_id", fk[0].ColumnName)
+		require.Equal(t, "fk_store_address", fk[0].ConstraintName)
+		require.Equal(t, "address", fk[0].ReferencedTableName)
+		require.Equal(t, "address_id", fk[0].ReferencedColumnName)
+		require.Equal(t, "store", fk[1].TableName)
+		require.Equal(t, "manager_staff_id", fk[1].ColumnName)
+		require.Equal(t, "fk_store_staff", fk[1].ConstraintName)
+		require.Equal(t, "staff", fk[1].ReferencedTableName)
+		require.Equal(t, "staff_id", fk[1].ReferencedColumnName)
 	})
 }

--- a/go/dbinfo/utils.go
+++ b/go/dbinfo/utils.go
@@ -130,3 +130,141 @@ func (dbh *DBHelper) getGlobalVariables() (map[string]string, error) {
 	}
 	return gv, nil
 }
+
+type primaryKey struct {
+	tableName string
+	columns   []string
+}
+type primaryKeys map[string]*primaryKey
+
+func (dbh *DBHelper) getPrimaryKeys() (primaryKeys, error) {
+	vtConn, cancel, err := dbh.GetConnection()
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+
+	pks := make(primaryKeys)
+	queryPrimaryKeys := "select table_name, column_name from information_schema.key_column_usage where constraint_name = 'PRIMARY' and table_schema = '%s' order by table_name"
+	query := fmt.Sprintf(queryPrimaryKeys, dbh.vtParams.DbName)
+	qr, err := vtConn.ExecuteFetch(query, -1, false)
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range qr.Rows {
+		tableName := row[0].ToString()
+		columnName := row[1].ToString()
+		pk, ok := pks[tableName]
+		if !ok {
+			pk = &primaryKey{tableName: tableName}
+			pks[tableName] = pk
+		}
+		pk.columns = append(pk.columns, columnName)
+	}
+	return pks, nil
+}
+
+type tableIndex struct {
+	tableName string
+	indexes   map[string]*index
+}
+type index struct {
+	indexName string
+	columns   []string
+	nonUnique bool
+}
+
+type indexes map[string]*tableIndex
+
+func (i *indexes) len() int {
+	return len(*i)
+}
+
+func (dbh *DBHelper) getIndexes() (indexes, error) {
+	vtConn, cancel, err := dbh.GetConnection()
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+
+	idxs := make(indexes)
+	queryIndexes := "select table_name, index_name, column_name, non_unique from information_schema.statistics where table_schema = '%s' order by table_name, index_name"
+	query := fmt.Sprintf(queryIndexes, dbh.vtParams.DbName)
+	qr, err := vtConn.ExecuteFetch(query, -1, false)
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range qr.Rows {
+		tableName := row[0].ToString()
+		indexName := row[1].ToString()
+		columnName := row[2].ToString()
+		nonUnique, _ := row[3].ToBool()
+		tidx, ok := idxs[tableName]
+		if !ok {
+			tidx = &tableIndex{tableName: tableName, indexes: make(map[string]*index)}
+			idxs[tableName] = tidx
+		}
+		idxName := indexName
+		if idxName == "PRIMARY" {
+			idxName = "PRIMARY_KEY"
+		}
+		idx, ok := tidx.indexes[idxName]
+		if !ok {
+			idx = &index{indexName: indexName, nonUnique: nonUnique}
+			tidx.indexes[idxName] = idx
+		}
+		idx.columns = append(idx.columns, columnName)
+	}
+	return idxs, nil
+}
+
+// Foreign Keys with Dependency Information
+// SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, CONSTRAINT_NAME, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME
+// FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+// WHERE TABLE_SCHEMA = 'your_database_name' AND REFERENCED_TABLE_NAME IS NOT NULL;
+
+type foreignKey struct {
+	tableName            string
+	columnName           string
+	constraintName       string
+	referencedTableName  string
+	referencedColumnName string
+}
+
+func (fk *foreignKey) String() string {
+	return fmt.Sprintf("Table: %s, Column: %s, Constraint: %s, RefTable: %s, RefColumn: %s", fk.tableName, fk.columnName, fk.constraintName, fk.referencedTableName, fk.referencedColumnName)
+}
+
+type foreignKeys map[string][]*foreignKey
+
+func (dbh *DBHelper) getForeignKeys() (foreignKeys, error) {
+	vtConn, cancel, err := dbh.GetConnection()
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+
+	fks := make(foreignKeys)
+	queryForeignKeys := "select table_name, column_name, constraint_name, referenced_table_name, referenced_column_name from information_schema.key_column_usage where table_schema = '%s' and referenced_table_name is not null"
+	query := fmt.Sprintf(queryForeignKeys, dbh.vtParams.DbName)
+	qr, err := vtConn.ExecuteFetch(query, -1, false)
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range qr.Rows {
+		tableName := row[0].ToString()
+		columnName := row[1].ToString()
+		constraintName := row[2].ToString()
+		referencedTableName := row[3].ToString()
+		referencedColumnName := row[4].ToString()
+		fk := &foreignKey{
+			tableName:            tableName,
+			columnName:           columnName,
+			constraintName:       constraintName,
+			referencedTableName:  referencedTableName,
+			referencedColumnName: referencedColumnName,
+		}
+		fks[tableName] = append(fks[tableName], fk)
+	}
+	return fks, nil
+}

--- a/go/testdata/sakila-dbinfo.json
+++ b/go/testdata/sakila-dbinfo.json
@@ -1,69 +1,49 @@
 {
   "fileType": "dbinfo",
-  "globalVariables": {
-    "binlog_format": "ROW",
-    "binlog_row_image": "FULL",
-    "log_bin": "ON"
-  },
   "tables": [
     {
-      "name": "inventory",
-      "rows": 4581,
+      "name": "actor",
+      "rows": 200,
       "columns": [
         {
-          "name": "inventory_id",
-          "type": "mediumint",
-          "keyType": "PRI",
-          "isNullable": false,
-          "extra": "auto_increment"
-        },
-        {
-          "name": "film_id",
+          "name": "actor_id",
           "type": "smallint",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "store_id",
-          "type": "tinyint",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "last_update",
-          "type": "timestamp",
-          "keyType": "",
-          "isNullable": false,
-          "extra": "DEFAULT_GENERATED on update CURRENT_TIMESTAMP"
-        }
-      ]
-    },
-    {
-      "name": "language",
-      "rows": 6,
-      "columns": [
-        {
-          "name": "language_id",
-          "type": "tinyint",
-          "keyType": "PRI",
-          "isNullable": false,
+          "keyType": "pri",
           "extra": "auto_increment"
         },
         {
-          "name": "name",
-          "type": "char",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
+          "name": "first_name",
+          "type": "varchar"
+        },
+        {
+          "name": "last_name",
+          "type": "varchar",
+          "keyType": "mul"
         },
         {
           "name": "last_update",
           "type": "timestamp",
-          "keyType": "",
-          "isNullable": false,
-          "extra": "DEFAULT_GENERATED on update CURRENT_TIMESTAMP"
+          "extra": "default_generated on update current_timestamp"
+        }
+      ],
+      "primaryKey": {
+        "columns": [
+          "actor_id"
+        ]
+      },
+      "indexes": [
+        {
+          "Name": "idx_actor_last_name",
+          "columns": [
+            "last_name"
+          ],
+          "nonUnique": true
+        },
+        {
+          "Name": "PRIMARY",
+          "columns": [
+            "actor_id"
+          ]
         }
       ]
     },
@@ -73,832 +53,20 @@
       "columns": [
         {
           "name": "actor_id",
-          "type": "smallint",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
+          "type": "smallint"
         },
         {
           "name": "first_name",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
+          "type": "varchar"
         },
         {
           "name": "last_name",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
+          "type": "varchar"
         },
         {
           "name": "film_info",
           "type": "text",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        }
-      ]
-    },
-    {
-      "name": "staff_list",
-      "rows": 0,
-      "columns": [
-        {
-          "name": "ID",
-          "type": "tinyint",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "name",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        },
-        {
-          "name": "address",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "zip code",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        },
-        {
-          "name": "phone",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "city",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "country",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "SID",
-          "type": "tinyint",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        }
-      ]
-    },
-    {
-      "name": "film_text",
-      "rows": 1000,
-      "columns": [
-        {
-          "name": "film_id",
-          "type": "smallint",
-          "keyType": "PRI",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "title",
-          "type": "varchar",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "description",
-          "type": "text",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        }
-      ]
-    },
-    {
-      "name": "country",
-      "rows": 109,
-      "columns": [
-        {
-          "name": "country_id",
-          "type": "smallint",
-          "keyType": "PRI",
-          "isNullable": false,
-          "extra": "auto_increment"
-        },
-        {
-          "name": "country",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "last_update",
-          "type": "timestamp",
-          "keyType": "",
-          "isNullable": false,
-          "extra": "DEFAULT_GENERATED on update CURRENT_TIMESTAMP"
-        }
-      ]
-    },
-    {
-      "name": "nicer_but_slower_film_list",
-      "rows": 0,
-      "columns": [
-        {
-          "name": "FID",
-          "type": "smallint",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "title",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "description",
-          "type": "text",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        },
-        {
-          "name": "category",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        },
-        {
-          "name": "price",
-          "type": "decimal",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "length",
-          "type": "smallint",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        },
-        {
-          "name": "rating",
-          "type": "enum",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        },
-        {
-          "name": "actors",
-          "type": "text",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        }
-      ]
-    },
-    {
-      "name": "film_list",
-      "rows": 0,
-      "columns": [
-        {
-          "name": "FID",
-          "type": "smallint",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "title",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "description",
-          "type": "text",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        },
-        {
-          "name": "category",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        },
-        {
-          "name": "price",
-          "type": "decimal",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "length",
-          "type": "smallint",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        },
-        {
-          "name": "rating",
-          "type": "enum",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        },
-        {
-          "name": "actors",
-          "type": "text",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        }
-      ]
-    },
-    {
-      "name": "sales_by_film_category",
-      "rows": 0,
-      "columns": [
-        {
-          "name": "category",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "total_sales",
-          "type": "decimal",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        }
-      ]
-    },
-    {
-      "name": "payment",
-      "rows": 16086,
-      "columns": [
-        {
-          "name": "payment_id",
-          "type": "smallint",
-          "keyType": "PRI",
-          "isNullable": false,
-          "extra": "auto_increment"
-        },
-        {
-          "name": "customer_id",
-          "type": "smallint",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "staff_id",
-          "type": "tinyint",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "rental_id",
-          "type": "int",
-          "keyType": "MUL",
-          "isNullable": true,
-          "extra": ""
-        },
-        {
-          "name": "amount",
-          "type": "decimal",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "payment_date",
-          "type": "datetime",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "last_update",
-          "type": "timestamp",
-          "keyType": "",
-          "isNullable": true,
-          "extra": "DEFAULT_GENERATED on update CURRENT_TIMESTAMP"
-        }
-      ]
-    },
-    {
-      "name": "staff",
-      "rows": 2,
-      "columns": [
-        {
-          "name": "staff_id",
-          "type": "tinyint",
-          "keyType": "PRI",
-          "isNullable": false,
-          "extra": "auto_increment"
-        },
-        {
-          "name": "first_name",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "last_name",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "address_id",
-          "type": "smallint",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "picture",
-          "type": "blob",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        },
-        {
-          "name": "email",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        },
-        {
-          "name": "store_id",
-          "type": "tinyint",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "active",
-          "type": "tinyint",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "username",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "password",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        },
-        {
-          "name": "last_update",
-          "type": "timestamp",
-          "keyType": "",
-          "isNullable": false,
-          "extra": "DEFAULT_GENERATED on update CURRENT_TIMESTAMP"
-        }
-      ]
-    },
-    {
-      "name": "film_category",
-      "rows": 1000,
-      "columns": [
-        {
-          "name": "film_id",
-          "type": "smallint",
-          "keyType": "PRI",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "category_id",
-          "type": "tinyint",
-          "keyType": "PRI",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "last_update",
-          "type": "timestamp",
-          "keyType": "",
-          "isNullable": false,
-          "extra": "DEFAULT_GENERATED on update CURRENT_TIMESTAMP"
-        }
-      ]
-    },
-    {
-      "name": "film_actor",
-      "rows": 5462,
-      "columns": [
-        {
-          "name": "actor_id",
-          "type": "smallint",
-          "keyType": "PRI",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "film_id",
-          "type": "smallint",
-          "keyType": "PRI",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "last_update",
-          "type": "timestamp",
-          "keyType": "",
-          "isNullable": false,
-          "extra": "DEFAULT_GENERATED on update CURRENT_TIMESTAMP"
-        }
-      ]
-    },
-    {
-      "name": "city",
-      "rows": 600,
-      "columns": [
-        {
-          "name": "city_id",
-          "type": "smallint",
-          "keyType": "PRI",
-          "isNullable": false,
-          "extra": "auto_increment"
-        },
-        {
-          "name": "city",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "country_id",
-          "type": "smallint",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "last_update",
-          "type": "timestamp",
-          "keyType": "",
-          "isNullable": false,
-          "extra": "DEFAULT_GENERATED on update CURRENT_TIMESTAMP"
-        }
-      ]
-    },
-    {
-      "name": "customer_list",
-      "rows": 0,
-      "columns": [
-        {
-          "name": "ID",
-          "type": "smallint",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "name",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        },
-        {
-          "name": "address",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "zip code",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        },
-        {
-          "name": "phone",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "city",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "country",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "notes",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "SID",
-          "type": "tinyint",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        }
-      ]
-    },
-    {
-      "name": "sales_by_store",
-      "rows": 0,
-      "columns": [
-        {
-          "name": "store",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        },
-        {
-          "name": "manager",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        },
-        {
-          "name": "total_sales",
-          "type": "decimal",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        }
-      ]
-    },
-    {
-      "name": "category",
-      "rows": 16,
-      "columns": [
-        {
-          "name": "category_id",
-          "type": "tinyint",
-          "keyType": "PRI",
-          "isNullable": false,
-          "extra": "auto_increment"
-        },
-        {
-          "name": "name",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "last_update",
-          "type": "timestamp",
-          "keyType": "",
-          "isNullable": false,
-          "extra": "DEFAULT_GENERATED on update CURRENT_TIMESTAMP"
-        }
-      ]
-    },
-    {
-      "name": "customer",
-      "rows": 599,
-      "columns": [
-        {
-          "name": "customer_id",
-          "type": "smallint",
-          "keyType": "PRI",
-          "isNullable": false,
-          "extra": "auto_increment"
-        },
-        {
-          "name": "store_id",
-          "type": "tinyint",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "first_name",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "last_name",
-          "type": "varchar",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "email",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        },
-        {
-          "name": "address_id",
-          "type": "smallint",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "active",
-          "type": "tinyint",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "create_date",
-          "type": "datetime",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "last_update",
-          "type": "timestamp",
-          "keyType": "",
-          "isNullable": true,
-          "extra": "DEFAULT_GENERATED on update CURRENT_TIMESTAMP"
-        }
-      ]
-    },
-    {
-      "name": "actor",
-      "rows": 200,
-      "columns": [
-        {
-          "name": "actor_id",
-          "type": "smallint",
-          "keyType": "PRI",
-          "isNullable": false,
-          "extra": "auto_increment"
-        },
-        {
-          "name": "first_name",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "last_name",
-          "type": "varchar",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "last_update",
-          "type": "timestamp",
-          "keyType": "",
-          "isNullable": false,
-          "extra": "DEFAULT_GENERATED on update CURRENT_TIMESTAMP"
-        }
-      ]
-    },
-    {
-      "name": "rental",
-      "rows": 15425,
-      "columns": [
-        {
-          "name": "rental_id",
-          "type": "int",
-          "keyType": "PRI",
-          "isNullable": false,
-          "extra": "auto_increment"
-        },
-        {
-          "name": "rental_date",
-          "type": "datetime",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "inventory_id",
-          "type": "mediumint",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "customer_id",
-          "type": "smallint",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "return_date",
-          "type": "datetime",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
-        },
-        {
-          "name": "staff_id",
-          "type": "tinyint",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "last_update",
-          "type": "timestamp",
-          "keyType": "",
-          "isNullable": false,
-          "extra": "DEFAULT_GENERATED on update CURRENT_TIMESTAMP"
-        }
-      ]
-    },
-    {
-      "name": "store",
-      "rows": 2,
-      "columns": [
-        {
-          "name": "store_id",
-          "type": "tinyint",
-          "keyType": "PRI",
-          "isNullable": false,
-          "extra": "auto_increment"
-        },
-        {
-          "name": "manager_staff_id",
-          "type": "tinyint",
-          "keyType": "UNI",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "address_id",
-          "type": "smallint",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
-        },
-        {
-          "name": "last_update",
-          "type": "timestamp",
-          "keyType": "",
-          "isNullable": false,
-          "extra": "DEFAULT_GENERATED on update CURRENT_TIMESTAMP"
+          "isNullable": true
         }
       ]
     },
@@ -909,65 +77,344 @@
         {
           "name": "address_id",
           "type": "smallint",
-          "keyType": "PRI",
-          "isNullable": false,
+          "keyType": "pri",
           "extra": "auto_increment"
         },
         {
           "name": "address",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
+          "type": "varchar"
         },
         {
           "name": "address2",
           "type": "varchar",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
+          "isNullable": true
         },
         {
           "name": "district",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
+          "type": "varchar"
         },
         {
           "name": "city_id",
           "type": "smallint",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
+          "keyType": "mul"
         },
         {
           "name": "postal_code",
           "type": "varchar",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
+          "isNullable": true
         },
         {
           "name": "phone",
-          "type": "varchar",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
+          "type": "varchar"
         },
         {
           "name": "location",
           "type": "geometry",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
+          "keyType": "mul"
         },
         {
           "name": "last_update",
           "type": "timestamp",
-          "keyType": "",
-          "isNullable": false,
-          "extra": "DEFAULT_GENERATED on update CURRENT_TIMESTAMP"
+          "extra": "default_generated on update current_timestamp"
+        }
+      ],
+      "primaryKey": {
+        "columns": [
+          "address_id"
+        ]
+      },
+      "indexes": [
+        {
+          "Name": "PRIMARY",
+          "columns": [
+            "address_id"
+          ]
+        },
+        {
+          "Name": "idx_fk_city_id",
+          "columns": [
+            "city_id"
+          ],
+          "nonUnique": true
+        },
+        {
+          "Name": "idx_location",
+          "columns": [
+            "location"
+          ],
+          "nonUnique": true
+        }
+      ],
+      "foreignKeys": [
+        {
+          "columnName": "city_id",
+          "constraintName": "fk_address_city",
+          "referencedTableName": "city",
+          "referencedColumnName": "city_id"
+        }
+      ]
+    },
+    {
+      "name": "category",
+      "rows": 16,
+      "columns": [
+        {
+          "name": "category_id",
+          "type": "tinyint",
+          "keyType": "pri",
+          "extra": "auto_increment"
+        },
+        {
+          "name": "name",
+          "type": "varchar"
+        },
+        {
+          "name": "last_update",
+          "type": "timestamp",
+          "extra": "default_generated on update current_timestamp"
+        }
+      ],
+      "primaryKey": {
+        "columns": [
+          "category_id"
+        ]
+      },
+      "indexes": [
+        {
+          "Name": "PRIMARY",
+          "columns": [
+            "category_id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "city",
+      "rows": 600,
+      "columns": [
+        {
+          "name": "city_id",
+          "type": "smallint",
+          "keyType": "pri",
+          "extra": "auto_increment"
+        },
+        {
+          "name": "city",
+          "type": "varchar"
+        },
+        {
+          "name": "country_id",
+          "type": "smallint",
+          "keyType": "mul"
+        },
+        {
+          "name": "last_update",
+          "type": "timestamp",
+          "extra": "default_generated on update current_timestamp"
+        }
+      ],
+      "primaryKey": {
+        "columns": [
+          "city_id"
+        ]
+      },
+      "indexes": [
+        {
+          "Name": "idx_fk_country_id",
+          "columns": [
+            "country_id"
+          ],
+          "nonUnique": true
+        },
+        {
+          "Name": "PRIMARY",
+          "columns": [
+            "city_id"
+          ]
+        }
+      ],
+      "foreignKeys": [
+        {
+          "columnName": "country_id",
+          "constraintName": "fk_city_country",
+          "referencedTableName": "country",
+          "referencedColumnName": "country_id"
+        }
+      ]
+    },
+    {
+      "name": "country",
+      "rows": 109,
+      "columns": [
+        {
+          "name": "country_id",
+          "type": "smallint",
+          "keyType": "pri",
+          "extra": "auto_increment"
+        },
+        {
+          "name": "country",
+          "type": "varchar"
+        },
+        {
+          "name": "last_update",
+          "type": "timestamp",
+          "extra": "default_generated on update current_timestamp"
+        }
+      ],
+      "primaryKey": {
+        "columns": [
+          "country_id"
+        ]
+      },
+      "indexes": [
+        {
+          "Name": "PRIMARY",
+          "columns": [
+            "country_id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "customer",
+      "rows": 599,
+      "columns": [
+        {
+          "name": "customer_id",
+          "type": "smallint",
+          "keyType": "pri",
+          "extra": "auto_increment"
+        },
+        {
+          "name": "store_id",
+          "type": "tinyint",
+          "keyType": "mul"
+        },
+        {
+          "name": "first_name",
+          "type": "varchar"
+        },
+        {
+          "name": "last_name",
+          "type": "varchar",
+          "keyType": "mul"
+        },
+        {
+          "name": "email",
+          "type": "varchar",
+          "isNullable": true
+        },
+        {
+          "name": "address_id",
+          "type": "smallint",
+          "keyType": "mul"
+        },
+        {
+          "name": "active",
+          "type": "tinyint"
+        },
+        {
+          "name": "create_date",
+          "type": "datetime"
+        },
+        {
+          "name": "last_update",
+          "type": "timestamp",
+          "isNullable": true,
+          "extra": "default_generated on update current_timestamp"
+        }
+      ],
+      "primaryKey": {
+        "columns": [
+          "customer_id"
+        ]
+      },
+      "indexes": [
+        {
+          "Name": "idx_fk_store_id",
+          "columns": [
+            "store_id"
+          ],
+          "nonUnique": true
+        },
+        {
+          "Name": "idx_last_name",
+          "columns": [
+            "last_name"
+          ],
+          "nonUnique": true
+        },
+        {
+          "Name": "PRIMARY",
+          "columns": [
+            "customer_id"
+          ]
+        },
+        {
+          "Name": "idx_fk_address_id",
+          "columns": [
+            "address_id"
+          ],
+          "nonUnique": true
+        }
+      ],
+      "foreignKeys": [
+        {
+          "columnName": "address_id",
+          "constraintName": "fk_customer_address",
+          "referencedTableName": "address",
+          "referencedColumnName": "address_id"
+        },
+        {
+          "columnName": "store_id",
+          "constraintName": "fk_customer_store",
+          "referencedTableName": "store",
+          "referencedColumnName": "store_id"
+        }
+      ]
+    },
+    {
+      "name": "customer_list",
+      "rows": 0,
+      "columns": [
+        {
+          "name": "ID",
+          "type": "smallint"
+        },
+        {
+          "name": "name",
+          "type": "varchar",
+          "isNullable": true
+        },
+        {
+          "name": "address",
+          "type": "varchar"
+        },
+        {
+          "name": "zip code",
+          "type": "varchar",
+          "isNullable": true
+        },
+        {
+          "name": "phone",
+          "type": "varchar"
+        },
+        {
+          "name": "city",
+          "type": "varchar"
+        },
+        {
+          "name": "country",
+          "type": "varchar"
+        },
+        {
+          "name": "notes",
+          "type": "varchar"
+        },
+        {
+          "name": "SID",
+          "type": "tinyint"
         }
       ]
     },
@@ -978,95 +425,909 @@
         {
           "name": "film_id",
           "type": "smallint",
-          "keyType": "PRI",
-          "isNullable": false,
+          "keyType": "pri",
           "extra": "auto_increment"
         },
         {
           "name": "title",
           "type": "varchar",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
+          "keyType": "mul"
         },
         {
           "name": "description",
           "type": "text",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
+          "isNullable": true
         },
         {
           "name": "release_year",
           "type": "year",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
+          "isNullable": true
         },
         {
           "name": "language_id",
           "type": "tinyint",
-          "keyType": "MUL",
-          "isNullable": false,
-          "extra": ""
+          "keyType": "mul"
         },
         {
           "name": "original_language_id",
           "type": "tinyint",
-          "keyType": "MUL",
-          "isNullable": true,
-          "extra": ""
+          "keyType": "mul",
+          "isNullable": true
         },
         {
           "name": "rental_duration",
-          "type": "tinyint",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
+          "type": "tinyint"
         },
         {
           "name": "rental_rate",
-          "type": "decimal",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
+          "type": "decimal"
         },
         {
           "name": "length",
           "type": "smallint",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
+          "isNullable": true
         },
         {
           "name": "replacement_cost",
-          "type": "decimal",
-          "keyType": "",
-          "isNullable": false,
-          "extra": ""
+          "type": "decimal"
         },
         {
           "name": "rating",
           "type": "enum",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
+          "isNullable": true
         },
         {
           "name": "special_features",
           "type": "set",
-          "keyType": "",
-          "isNullable": true,
-          "extra": ""
+          "isNullable": true
         },
         {
           "name": "last_update",
           "type": "timestamp",
-          "keyType": "",
-          "isNullable": false,
-          "extra": "DEFAULT_GENERATED on update CURRENT_TIMESTAMP"
+          "extra": "default_generated on update current_timestamp"
+        }
+      ],
+      "primaryKey": {
+        "columns": [
+          "film_id"
+        ]
+      },
+      "indexes": [
+        {
+          "Name": "idx_fk_language_id",
+          "columns": [
+            "language_id"
+          ],
+          "nonUnique": true
+        },
+        {
+          "Name": "idx_fk_original_language_id",
+          "columns": [
+            "original_language_id"
+          ],
+          "nonUnique": true
+        },
+        {
+          "Name": "idx_title",
+          "columns": [
+            "title"
+          ],
+          "nonUnique": true
+        },
+        {
+          "Name": "PRIMARY",
+          "columns": [
+            "film_id"
+          ]
+        }
+      ],
+      "foreignKeys": [
+        {
+          "columnName": "language_id",
+          "constraintName": "fk_film_language",
+          "referencedTableName": "language",
+          "referencedColumnName": "language_id"
+        },
+        {
+          "columnName": "original_language_id",
+          "constraintName": "fk_film_language_original",
+          "referencedTableName": "language",
+          "referencedColumnName": "language_id"
+        }
+      ]
+    },
+    {
+      "name": "film_actor",
+      "rows": 5462,
+      "columns": [
+        {
+          "name": "actor_id",
+          "type": "smallint",
+          "keyType": "pri"
+        },
+        {
+          "name": "film_id",
+          "type": "smallint",
+          "keyType": "pri"
+        },
+        {
+          "name": "last_update",
+          "type": "timestamp",
+          "extra": "default_generated on update current_timestamp"
+        }
+      ],
+      "primaryKey": {
+        "columns": [
+          "actor_id",
+          "film_id"
+        ]
+      },
+      "indexes": [
+        {
+          "Name": "idx_fk_film_id",
+          "columns": [
+            "film_id"
+          ],
+          "nonUnique": true
+        },
+        {
+          "Name": "PRIMARY",
+          "columns": [
+            "actor_id",
+            "film_id"
+          ]
+        }
+      ],
+      "foreignKeys": [
+        {
+          "columnName": "actor_id",
+          "constraintName": "fk_film_actor_actor",
+          "referencedTableName": "actor",
+          "referencedColumnName": "actor_id"
+        },
+        {
+          "columnName": "film_id",
+          "constraintName": "fk_film_actor_film",
+          "referencedTableName": "film",
+          "referencedColumnName": "film_id"
+        }
+      ]
+    },
+    {
+      "name": "film_category",
+      "rows": 1000,
+      "columns": [
+        {
+          "name": "film_id",
+          "type": "smallint",
+          "keyType": "pri"
+        },
+        {
+          "name": "category_id",
+          "type": "tinyint",
+          "keyType": "pri"
+        },
+        {
+          "name": "last_update",
+          "type": "timestamp",
+          "extra": "default_generated on update current_timestamp"
+        }
+      ],
+      "primaryKey": {
+        "columns": [
+          "film_id",
+          "category_id"
+        ]
+      },
+      "indexes": [
+        {
+          "Name": "fk_film_category_category",
+          "columns": [
+            "category_id"
+          ],
+          "nonUnique": true
+        },
+        {
+          "Name": "PRIMARY",
+          "columns": [
+            "film_id",
+            "category_id"
+          ]
+        }
+      ],
+      "foreignKeys": [
+        {
+          "columnName": "category_id",
+          "constraintName": "fk_film_category_category",
+          "referencedTableName": "category",
+          "referencedColumnName": "category_id"
+        },
+        {
+          "columnName": "film_id",
+          "constraintName": "fk_film_category_film",
+          "referencedTableName": "film",
+          "referencedColumnName": "film_id"
+        }
+      ]
+    },
+    {
+      "name": "film_list",
+      "rows": 0,
+      "columns": [
+        {
+          "name": "FID",
+          "type": "smallint"
+        },
+        {
+          "name": "title",
+          "type": "varchar"
+        },
+        {
+          "name": "description",
+          "type": "text",
+          "isNullable": true
+        },
+        {
+          "name": "category",
+          "type": "varchar",
+          "isNullable": true
+        },
+        {
+          "name": "price",
+          "type": "decimal"
+        },
+        {
+          "name": "length",
+          "type": "smallint",
+          "isNullable": true
+        },
+        {
+          "name": "rating",
+          "type": "enum",
+          "isNullable": true
+        },
+        {
+          "name": "actors",
+          "type": "text",
+          "isNullable": true
+        }
+      ]
+    },
+    {
+      "name": "film_text",
+      "rows": 1000,
+      "columns": [
+        {
+          "name": "film_id",
+          "type": "smallint",
+          "keyType": "pri"
+        },
+        {
+          "name": "title",
+          "type": "varchar",
+          "keyType": "mul"
+        },
+        {
+          "name": "description",
+          "type": "text",
+          "isNullable": true
+        }
+      ],
+      "primaryKey": {
+        "columns": [
+          "film_id"
+        ]
+      },
+      "indexes": [
+        {
+          "Name": "PRIMARY",
+          "columns": [
+            "film_id"
+          ]
+        },
+        {
+          "Name": "idx_title_description",
+          "columns": [
+            "title",
+            "description"
+          ],
+          "nonUnique": true
+        }
+      ]
+    },
+    {
+      "name": "inventory",
+      "rows": 4581,
+      "columns": [
+        {
+          "name": "inventory_id",
+          "type": "mediumint",
+          "keyType": "pri",
+          "extra": "auto_increment"
+        },
+        {
+          "name": "film_id",
+          "type": "smallint",
+          "keyType": "mul"
+        },
+        {
+          "name": "store_id",
+          "type": "tinyint",
+          "keyType": "mul"
+        },
+        {
+          "name": "last_update",
+          "type": "timestamp",
+          "extra": "default_generated on update current_timestamp"
+        }
+      ],
+      "primaryKey": {
+        "columns": [
+          "inventory_id"
+        ]
+      },
+      "indexes": [
+        {
+          "Name": "idx_fk_film_id",
+          "columns": [
+            "film_id"
+          ],
+          "nonUnique": true
+        },
+        {
+          "Name": "idx_store_id_film_id",
+          "columns": [
+            "store_id",
+            "film_id"
+          ],
+          "nonUnique": true
+        },
+        {
+          "Name": "PRIMARY",
+          "columns": [
+            "inventory_id"
+          ]
+        }
+      ],
+      "foreignKeys": [
+        {
+          "columnName": "film_id",
+          "constraintName": "fk_inventory_film",
+          "referencedTableName": "film",
+          "referencedColumnName": "film_id"
+        },
+        {
+          "columnName": "store_id",
+          "constraintName": "fk_inventory_store",
+          "referencedTableName": "store",
+          "referencedColumnName": "store_id"
+        }
+      ]
+    },
+    {
+      "name": "language",
+      "rows": 6,
+      "columns": [
+        {
+          "name": "language_id",
+          "type": "tinyint",
+          "keyType": "pri",
+          "extra": "auto_increment"
+        },
+        {
+          "name": "name",
+          "type": "char"
+        },
+        {
+          "name": "last_update",
+          "type": "timestamp",
+          "extra": "default_generated on update current_timestamp"
+        }
+      ],
+      "primaryKey": {
+        "columns": [
+          "language_id"
+        ]
+      },
+      "indexes": [
+        {
+          "Name": "PRIMARY",
+          "columns": [
+            "language_id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "nicer_but_slower_film_list",
+      "rows": 0,
+      "columns": [
+        {
+          "name": "FID",
+          "type": "smallint"
+        },
+        {
+          "name": "title",
+          "type": "varchar"
+        },
+        {
+          "name": "description",
+          "type": "text",
+          "isNullable": true
+        },
+        {
+          "name": "category",
+          "type": "varchar",
+          "isNullable": true
+        },
+        {
+          "name": "price",
+          "type": "decimal"
+        },
+        {
+          "name": "length",
+          "type": "smallint",
+          "isNullable": true
+        },
+        {
+          "name": "rating",
+          "type": "enum",
+          "isNullable": true
+        },
+        {
+          "name": "actors",
+          "type": "text",
+          "isNullable": true
+        }
+      ]
+    },
+    {
+      "name": "payment",
+      "rows": 16086,
+      "columns": [
+        {
+          "name": "payment_id",
+          "type": "smallint",
+          "keyType": "pri",
+          "extra": "auto_increment"
+        },
+        {
+          "name": "customer_id",
+          "type": "smallint",
+          "keyType": "mul"
+        },
+        {
+          "name": "staff_id",
+          "type": "tinyint",
+          "keyType": "mul"
+        },
+        {
+          "name": "rental_id",
+          "type": "int",
+          "keyType": "mul",
+          "isNullable": true
+        },
+        {
+          "name": "amount",
+          "type": "decimal"
+        },
+        {
+          "name": "payment_date",
+          "type": "datetime"
+        },
+        {
+          "name": "last_update",
+          "type": "timestamp",
+          "isNullable": true,
+          "extra": "default_generated on update current_timestamp"
+        }
+      ],
+      "primaryKey": {
+        "columns": [
+          "payment_id"
+        ]
+      },
+      "indexes": [
+        {
+          "Name": "idx_fk_staff_id",
+          "columns": [
+            "staff_id"
+          ],
+          "nonUnique": true
+        },
+        {
+          "Name": "PRIMARY",
+          "columns": [
+            "payment_id"
+          ]
+        },
+        {
+          "Name": "fk_payment_rental",
+          "columns": [
+            "rental_id"
+          ],
+          "nonUnique": true
+        },
+        {
+          "Name": "idx_fk_customer_id",
+          "columns": [
+            "customer_id"
+          ],
+          "nonUnique": true
+        }
+      ],
+      "foreignKeys": [
+        {
+          "columnName": "customer_id",
+          "constraintName": "fk_payment_customer",
+          "referencedTableName": "customer",
+          "referencedColumnName": "customer_id"
+        },
+        {
+          "columnName": "rental_id",
+          "constraintName": "fk_payment_rental",
+          "referencedTableName": "rental",
+          "referencedColumnName": "rental_id"
+        },
+        {
+          "columnName": "staff_id",
+          "constraintName": "fk_payment_staff",
+          "referencedTableName": "staff",
+          "referencedColumnName": "staff_id"
+        }
+      ]
+    },
+    {
+      "name": "rental",
+      "rows": 15425,
+      "columns": [
+        {
+          "name": "rental_id",
+          "type": "int",
+          "keyType": "pri",
+          "extra": "auto_increment"
+        },
+        {
+          "name": "rental_date",
+          "type": "datetime",
+          "keyType": "mul"
+        },
+        {
+          "name": "inventory_id",
+          "type": "mediumint",
+          "keyType": "mul"
+        },
+        {
+          "name": "customer_id",
+          "type": "smallint",
+          "keyType": "mul"
+        },
+        {
+          "name": "return_date",
+          "type": "datetime",
+          "isNullable": true
+        },
+        {
+          "name": "staff_id",
+          "type": "tinyint",
+          "keyType": "mul"
+        },
+        {
+          "name": "last_update",
+          "type": "timestamp",
+          "extra": "default_generated on update current_timestamp"
+        }
+      ],
+      "primaryKey": {
+        "columns": [
+          "rental_id"
+        ]
+      },
+      "indexes": [
+        {
+          "Name": "rental_date",
+          "columns": [
+            "rental_date",
+            "inventory_id",
+            "customer_id"
+          ]
+        },
+        {
+          "Name": "idx_fk_customer_id",
+          "columns": [
+            "customer_id"
+          ],
+          "nonUnique": true
+        },
+        {
+          "Name": "idx_fk_inventory_id",
+          "columns": [
+            "inventory_id"
+          ],
+          "nonUnique": true
+        },
+        {
+          "Name": "idx_fk_staff_id",
+          "columns": [
+            "staff_id"
+          ],
+          "nonUnique": true
+        },
+        {
+          "Name": "PRIMARY",
+          "columns": [
+            "rental_id"
+          ]
+        }
+      ],
+      "foreignKeys": [
+        {
+          "columnName": "customer_id",
+          "constraintName": "fk_rental_customer",
+          "referencedTableName": "customer",
+          "referencedColumnName": "customer_id"
+        },
+        {
+          "columnName": "inventory_id",
+          "constraintName": "fk_rental_inventory",
+          "referencedTableName": "inventory",
+          "referencedColumnName": "inventory_id"
+        },
+        {
+          "columnName": "staff_id",
+          "constraintName": "fk_rental_staff",
+          "referencedTableName": "staff",
+          "referencedColumnName": "staff_id"
+        }
+      ]
+    },
+    {
+      "name": "sales_by_film_category",
+      "rows": 0,
+      "columns": [
+        {
+          "name": "category",
+          "type": "varchar"
+        },
+        {
+          "name": "total_sales",
+          "type": "decimal",
+          "isNullable": true
+        }
+      ]
+    },
+    {
+      "name": "sales_by_store",
+      "rows": 0,
+      "columns": [
+        {
+          "name": "store",
+          "type": "varchar",
+          "isNullable": true
+        },
+        {
+          "name": "manager",
+          "type": "varchar",
+          "isNullable": true
+        },
+        {
+          "name": "total_sales",
+          "type": "decimal",
+          "isNullable": true
+        }
+      ]
+    },
+    {
+      "name": "staff",
+      "rows": 2,
+      "columns": [
+        {
+          "name": "staff_id",
+          "type": "tinyint",
+          "keyType": "pri",
+          "extra": "auto_increment"
+        },
+        {
+          "name": "first_name",
+          "type": "varchar"
+        },
+        {
+          "name": "last_name",
+          "type": "varchar"
+        },
+        {
+          "name": "address_id",
+          "type": "smallint",
+          "keyType": "mul"
+        },
+        {
+          "name": "picture",
+          "type": "blob",
+          "isNullable": true
+        },
+        {
+          "name": "email",
+          "type": "varchar",
+          "isNullable": true
+        },
+        {
+          "name": "store_id",
+          "type": "tinyint",
+          "keyType": "mul"
+        },
+        {
+          "name": "active",
+          "type": "tinyint"
+        },
+        {
+          "name": "username",
+          "type": "varchar"
+        },
+        {
+          "name": "password",
+          "type": "varchar",
+          "isNullable": true
+        },
+        {
+          "name": "last_update",
+          "type": "timestamp",
+          "extra": "default_generated on update current_timestamp"
+        }
+      ],
+      "primaryKey": {
+        "columns": [
+          "staff_id"
+        ]
+      },
+      "indexes": [
+        {
+          "Name": "idx_fk_address_id",
+          "columns": [
+            "address_id"
+          ],
+          "nonUnique": true
+        },
+        {
+          "Name": "idx_fk_store_id",
+          "columns": [
+            "store_id"
+          ],
+          "nonUnique": true
+        },
+        {
+          "Name": "PRIMARY",
+          "columns": [
+            "staff_id"
+          ]
+        }
+      ],
+      "foreignKeys": [
+        {
+          "columnName": "address_id",
+          "constraintName": "fk_staff_address",
+          "referencedTableName": "address",
+          "referencedColumnName": "address_id"
+        },
+        {
+          "columnName": "store_id",
+          "constraintName": "fk_staff_store",
+          "referencedTableName": "store",
+          "referencedColumnName": "store_id"
+        }
+      ]
+    },
+    {
+      "name": "staff_list",
+      "rows": 0,
+      "columns": [
+        {
+          "name": "ID",
+          "type": "tinyint"
+        },
+        {
+          "name": "name",
+          "type": "varchar",
+          "isNullable": true
+        },
+        {
+          "name": "address",
+          "type": "varchar"
+        },
+        {
+          "name": "zip code",
+          "type": "varchar",
+          "isNullable": true
+        },
+        {
+          "name": "phone",
+          "type": "varchar"
+        },
+        {
+          "name": "city",
+          "type": "varchar"
+        },
+        {
+          "name": "country",
+          "type": "varchar"
+        },
+        {
+          "name": "SID",
+          "type": "tinyint"
+        }
+      ]
+    },
+    {
+      "name": "store",
+      "rows": 2,
+      "columns": [
+        {
+          "name": "store_id",
+          "type": "tinyint",
+          "keyType": "pri",
+          "extra": "auto_increment"
+        },
+        {
+          "name": "manager_staff_id",
+          "type": "tinyint",
+          "keyType": "uni"
+        },
+        {
+          "name": "address_id",
+          "type": "smallint",
+          "keyType": "mul"
+        },
+        {
+          "name": "last_update",
+          "type": "timestamp",
+          "extra": "default_generated on update current_timestamp"
+        }
+      ],
+      "primaryKey": {
+        "columns": [
+          "store_id"
+        ]
+      },
+      "indexes": [
+        {
+          "Name": "idx_fk_address_id",
+          "columns": [
+            "address_id"
+          ],
+          "nonUnique": true
+        },
+        {
+          "Name": "idx_unique_manager",
+          "columns": [
+            "manager_staff_id"
+          ]
+        },
+        {
+          "Name": "PRIMARY",
+          "columns": [
+            "store_id"
+          ]
+        }
+      ],
+      "foreignKeys": [
+        {
+          "columnName": "address_id",
+          "constraintName": "fk_store_address",
+          "referencedTableName": "address",
+          "referencedColumnName": "address_id"
+        },
+        {
+          "columnName": "manager_staff_id",
+          "constraintName": "fk_store_staff",
+          "referencedTableName": "staff",
+          "referencedColumnName": "staff_id"
         }
       ]
     }
-  ]
+  ],
+  "globalVariables": {
+    "binlog_format": "ROW",
+    "binlog_row_image": "FULL",
+    "gtid_mode": "OFF",
+    "log_bin": "ON"
+  }
 }


### PR DESCRIPTION
Enhance `dbinfo` to add, per table,
* primary keys
* indexes
* foreign keys: info on child and parent columns